### PR TITLE
Borrowing flows: MVP UI integration

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -29,14 +29,14 @@ class ItemAction(TextChoices):
     user when viewing an Item.
     """
 
-    REQUEST_ITEM = "request_item", "Request Item"
-    ACCEPT_REQUEST = "accept_request", "Accept Request"
-    REJECT_REQUEST = "reject_request", "Reject Request"
-    MARK_COLLECTED = "mark_collected", "Mark Collected"
-    CONFIRM_COLLECTED = "confirm_collected", "Confirm Collected"
-    MARK_RETURNED = "mark_returned", "Mark Returned"
-    CONFIRM_RETURNED = "confirm_returned", "Confirm Returned"
-    CANCEL_REQUEST = "cancel_request", "Cancel Request"
+    REQUEST_ITEM = "REQUEST_ITEM", "Request Item"
+    ACCEPT_REQUEST = "ACCEPT_REQUEST", "Accept Request"
+    REJECT_REQUEST = "REJECT_REQUEST", "Reject Request"
+    MARK_COLLECTED = "MARK_COLLECTED", "Mark Collected"
+    CONFIRM_COLLECTED = "CONFIRM_COLLECTED", "Confirm Collected"
+    MARK_RETURNED = "MARK_RETURNED", "Mark Returned"
+    CONFIRM_RETURNED = "CONFIRM_RETURNED", "Confirm Returned"
+    CANCEL_REQUEST = "CANCEL_REQUEST", "Cancel Request"
 
 
 class ItemCategory(Model):
@@ -212,6 +212,7 @@ class Item(Model):
                     status__in=[
                         TransactionStatus.RETURNED,
                         TransactionStatus.REJECTED,
+                        TransactionStatus.CANCELLED,
                     ]
                 )
             )

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -69,6 +69,7 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
         )
 
     try:
+        req_action = req_action.upper()
         item.process_action(user=user, action=ItemAction(req_action))
     except InvalidItemAction as e:
         return HttpResponse(str(e), status=400)
@@ -120,7 +121,7 @@ class ItemDetailView(BorrowdTemplateFinderMixin, DetailView[Item]):
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         user: BorrowdUser = self.request.user  # type: ignore[assignment]
-        context["action_options"] = self.object.get_actions_for(user=user)
+        context["item_actions"] = self.object.get_actions_for(user=user)
         return context
 
 

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -84,7 +84,7 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
 
     return render(
         request,
-        template_name="components/item_action_buttons.html",
+        template_name="components/items/action_buttons.html",
         context={
             "item": item,
             "item_actions": next_actions,

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
      <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
 </head>
-<body x-data class="flex flex-col min-h-screen">
+<body x-data class="flex flex-col min-h-screen" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
 
     {% include "includes/messages.html" %}
     {% include "includes/header.html" %}
@@ -18,5 +18,6 @@
     {% endblock %}
 
     {% include "includes/footer.html" %}
+    <script src="https://unpkg.com/htmx.org@1.9.3"></script>
 </body>
 </html>

--- a/templates/components/item_action_buttons.html
+++ b/templates/components/item_action_buttons.html
@@ -1,5 +1,0 @@
-{% for action in item_actions %}
-    <button type="button" onclick="{% url 'item-borrow' item.pk %}">
-        {{ action.label }}
-    </button>
-{% endfor %}

--- a/templates/components/items/action_buttons.html
+++ b/templates/components/items/action_buttons.html
@@ -1,0 +1,16 @@
+<ul>
+    {% for action in item_actions %}
+        <li>
+            <button
+                type="button"
+                hx-post="{% url 'item-borrow' item.pk %}"
+                hx-vals='{"action": "{{ action.name }}"}'
+                hx-trigger="click"
+                hx-swap="outerHTML"
+                hx-target="closest ul"
+            >
+                {{ action.label }}
+            </button>
+        </li>
+    {% endfor %}
+</ul>

--- a/templates/items/item_detail.html
+++ b/templates/items/item_detail.html
@@ -5,6 +5,7 @@
 <c-box>
     <c-h1>{{ object.name }}</c-h1>
     <p>{{ object.description }}</p>
+    <c-items.action-buttons />
 
     <c-gallery>
     {% for photo in view.object.photos.all %}

--- a/tests/test_borrowing_flows.py
+++ b/tests/test_borrowing_flows.py
@@ -79,7 +79,7 @@ class RejectedFlowTest(SimpleTestCase):
         cls.borrower.delete()
         super().tearDownClass()
 
-    def test_010_borrower_action_options_initial_state(self) -> None:
+    def test_010_borrower_item_actions_initial_state(self) -> None:
         """
         Borrower's initial option is to Request Item.
         """
@@ -103,18 +103,18 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        action_options = response.context_data["action_options"]
+        item_actions = response.context_data["item_actions"]
 
         #
         # Assert
         #
         ## Check if the owner can see the item
         self.assertTupleEqual(
-            action_options,
+            item_actions,
             (ItemAction.REQUEST_ITEM,),
         )
 
-    def test_020_lender_action_options_initial_state(self) -> None:
+    def test_020_lender_item_actions_initial_state(self) -> None:
         """
         Lender can't borrow their own item.
         """
@@ -138,13 +138,13 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        action_options = response.context_data["action_options"]
+        item_actions = response.context_data["item_actions"]
 
         #
         # Assert
         #
         ## No action options for the lender at this point
-        self.assertTupleEqual(action_options, tuple())
+        self.assertTupleEqual(item_actions, tuple())
 
     def test_030_borrower_request_item_action(self) -> None:
         """
@@ -186,7 +186,7 @@ class RejectedFlowTest(SimpleTestCase):
             "Cancel Request",
         )
 
-    def test_040_lender_action_options_following_request(self) -> None:
+    def test_040_lender_item_actions_following_request(self) -> None:
         """
         Once Item is Requested, Lender can Accept or Reject.
         """
@@ -210,14 +210,14 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        action_options = response.context_data["action_options"]
+        item_actions = response.context_data["item_actions"]
 
         #
         # Assert
         #
         ## Check if the owner can see the item
         self.assertTupleEqual(
-            action_options,
+            item_actions,
             (
                 ItemAction.ACCEPT_REQUEST,
                 ItemAction.REJECT_REQUEST,


### PR DESCRIPTION
Not yet implemented:

* Full testing for e2e workflow (but it does work!)
* More mitigation for edge cases

PR includes:

* Borrowing flow: small cleanups
    
    * Standardize on "item_actions", not "action_options".
    * Add "CANCELLED" to exclusion for finding "current transaction"
    * Normalize ItemAction enum capitalization
    
    Re the last point: Turns out, if you define an enum like this:
    
        class Foo(TextChoices):
            MY_BAR = "my_bar", "My Bar"
    
    Then you have to do lookups in one of the following ways:
    
        Foo("my_bar")
        # ...or ...
        Foo["MY_BAR"]
    
    Using the wrong capitalization with the wrong brackets (function
    call vs dict member lookup) causes problems!
    
    Hence, standardizing at this point to both name and value as
    uppercase, to reduce opportunities for self-sabotage later.

* Add HTMX plumbing.
    
    Pretty minimal, ey? :)
    
    Although soon we should get this, Tailwind and Alpine bundling locally
    via `django-vite`. If for no other reason than so that I can keep
    hacking locally on trains with no WiFi.

* Borrowing flows: item action buttons.
    
    * Item action buttons component to an /items/ subdir
    * Add in HTMX attributes
    * Add component to item detail template
