### PR TITLE
Configure prod email proxy

### DIFF
--- a/borrowd/config/prod/django.py
+++ b/borrowd/config/prod/django.py
@@ -59,9 +59,11 @@ if env("PLATFORM_APPLICATION_NAME") is not None:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     EMAIL_HOST = env("PLATFORM_SMTP_HOST", default=None)
     EMAIL_PORT = 25
+    DEFAULT_FROM_EMAIL = "noreply@borrowd.org"
+    # Platform.sh proxies emails internally and encrypts before sending off-platform
+    # TLS should be enabled whenever a 3rd-party SMTP service (e.g. SendGrid) is configured
     EMAIL_USE_TLS = False
     EMAIL_USE_SSL = False
-    DEFAULT_FROM_EMAIL = "noreply@borrowd.org"
 
     # This variable must always match the primary database relationship name, configured in .platform.app.yaml
     PLATFORMSH_DB_RELATIONSHIP = "db"


### PR DESCRIPTION
Configures prod to use the basic SMTP proxy offered by Platform.sh. This is a non-guaranteed, best-effort service so this may need to be improved in the future to something like SendGrid, but should be enough for now.