### PR TITLE
Email group invite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "args": [
+                "runserver"
+            ],
+            "autoStartBrowser": false,
+            "django": true,
+            "name": "Python Debugger: Django",
+            "program": "${workspaceFolder}/manage.py",
+            "request": "launch",
+            "type": "debugpy"
+        }
+    ],
+    "version": "0.2.0"
+}

--- a/borrowd/config/prod/django.py
+++ b/borrowd/config/prod/django.py
@@ -56,6 +56,13 @@ if env("PLATFORM_APPLICATION_NAME") is not None:
     # This should already be set correctly by the base config, but including this as insurance
     SECRET_KEY = env("PLATFORM_PROJECT_ENTROPY")
 
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = env("PLATFORM_SMTP_HOST", default=None)
+    EMAIL_PORT = 25
+    EMAIL_USE_TLS = False
+    EMAIL_USE_SSL = False
+    DEFAULT_FROM_EMAIL = "noreply@borrowd.org"
+
     # This variable must always match the primary database relationship name, configured in .platform.app.yaml
     PLATFORMSH_DB_RELATIONSHIP = "db"
 

--- a/borrowd_groups/forms.py
+++ b/borrowd_groups/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms import formset_factory
 
 from borrowd.models import TrustLevel
 from borrowd_groups.models import BorrowdGroup
@@ -30,3 +31,16 @@ class GroupJoinForm(forms.Form):
         required=True,
         label="Your Trust Level with this Group",
     )
+
+
+class GroupInviteEmailForm(forms.Form):
+    email = forms.EmailField(
+        required=True,
+        label="Email",
+    )
+
+
+# using a formset to support multiple email invites, but only showing single email input for now
+GroupInviteEmailFormSet = formset_factory(
+    GroupInviteEmailForm, extra=0, max_num=10, min_num=1, validate_min=True
+)

--- a/borrowd_groups/models.py
+++ b/borrowd_groups/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Never  # Unfortunately needed for more mypy shenanigans
+from typing import Any  # Unfortunately needed for more mypy shenanigans
 
 from django.contrib.auth.models import Group, GroupManager
 from django.db.models import (
@@ -18,6 +18,7 @@ from django.db.models import (
 from django.urls import reverse
 from guardian.mixins import GuardianGroupMixin
 from guardian.models import GroupObjectPermissionAbstract
+from typing_extensions import Never
 
 from borrowd.models import TrustLevel
 from borrowd_groups.exceptions import ExistingMemberException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "pillow>=11.1.0",
     "psycopg[binary]>=3.1",
     "gunicorn>=23.0.0",
+    "typing-extensions>=4.13.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,6 +98,10 @@ sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \
     --hash=sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca
     # via django
+typing-extensions==4.13.2 \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
+    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
+    # via borrowd
 tzdata==2025.2 ; sys_platform == 'win32' \
     --hash=sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8 \
     --hash=sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -1,0 +1,5 @@
+<input type="{{ type|default:'text' }}" name="{{ field.html_name }}" id="{{ field.id_for_label }}"
+    class="w-3/4 px-3 py-2 mt-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 {{class}}"
+    value="{{ field.value|default:'' }}"
+    placeholder="{{placeholder}}"
+/>

--- a/templates/groups/group_invite.html
+++ b/templates/groups/group_invite.html
@@ -9,6 +9,30 @@
             {{ join_url}}
         </p>
         <c-button @click.prevent="onShareClick">Copy Link</c-button>
+        <div class="my-6 border-y-2 py-2">
+            <c-h2>Share by Email</c-h2>
+            <form method="POST">
+                {% csrf_token %}
+                {{ formset.management_form }}
+                {% comment %} Might be a good place for some JS to dynamically add additional inputs {% endcomment %}
+                {% for form in formset %}
+                    <div class="mb-4">
+                        {{ form.email.label_tag }}
+                        <input type="email" name="{{ form.email.html_name }}" id="{{ form.email.id_for_label }}"
+                            class="w-3/4 px-3 py-2 mt-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            value="{{ filter.form.email.value|default:'' }}"
+                            placeholder="Enter email address to share invite code...">
+                        {% for error in form.email.errors %}
+                            <div class="error">{{ error }}</div>
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+                <c-button type="submit">Share</c-button>
+            </form>
+        </div>
+        <c-button-nav url="{% url 'borrowd_groups:group-detail' object.pk %}">
+            Cancel
+        </c-button-nav>
     </div>
 </c-box>
 <script>

--- a/templates/groups/group_invite.html
+++ b/templates/groups/group_invite.html
@@ -14,14 +14,14 @@
             <form method="POST">
                 {% csrf_token %}
                 {{ formset.management_form }}
-                {% comment %} Might be a good place for some JS to dynamically add additional inputs {% endcomment %}
+                {% comment %} Might be a good place for some JS to dynamically add additional email inputs {% endcomment %}
                 {% for form in formset %}
                     <div class="mb-4">
                         {{ form.email.label_tag }}
-                        <input type="email" name="{{ form.email.html_name }}" id="{{ form.email.id_for_label }}"
-                            class="w-3/4 px-3 py-2 mt-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                            value="{{ filter.form.email.value|default:'' }}"
-                            placeholder="Enter email address to share invite code...">
+                        <c-text-input type="email" :field=form.email
+                            placeholder="Enter email address to share invite code..."
+                        />
+
                         {% for error in form.email.errors %}
                             <div class="error">{{ error }}</div>
                         {% endfor %}

--- a/templates/groups/group_invite_email.html
+++ b/templates/groups/group_invite_email.html
@@ -1,0 +1,28 @@
+{% extends "layouts/email.html" %}
+
+{% block title %}Group Invitation{% endblock %}
+
+{% block header_title %}
+    You've Been Invited to Join {{ group.name }}
+{% endblock %}
+
+{% block content %}
+    <p>Hello,</p>
+
+    <p>{{ sender.get_full_name|default:sender.username }} has invited you to join the group "{{ group.name }}" on Borrow'd.</p>
+
+    <p>This group allows members to share items, track item loans, and stay organized together.</p>
+
+    <p>To accept this invitation and join the group, please click the button below:</p>
+
+    <p>
+        <a href="{{ join_url }}" class="button">Join Group</a>
+    </p>
+
+    <p>If the button doesn't work, you can copy and paste this link into your browser:</p>
+    <p>{{ join_url }}</p>
+{% endblock %}
+
+{% block footer_message %}
+    This invitation was sent to you by {{ sender.get_full_name|default:sender.username }}. If you believe this was sent in error, you can safely ignore this email.
+{% endblock %}

--- a/templates/layouts/email.html
+++ b/templates/layouts/email.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Borrow'd - {% block title %}{% endblock %}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            margin-bottom: 20px;
+        }
+        .content {
+            margin-bottom: 30px;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #4CAF50;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+        .footer {
+            font-size: 12px;
+            color: #777;
+            margin-top: 30px;
+            border-top: 1px solid #eee;
+            padding-top: 20px;
+        }
+        {% block extra_styles %}{% endblock %}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h2>{% block header_title %}{% endblock %}</h2>
+    </div>
+
+    <div class="content">
+        {% block content %}{% endblock %}
+    </div>
+
+    <div class="footer">
+        {% block footer %}
+        <p>{% block footer_message %}{% endblock %}</p>
+        <p>&copy; {% now "Y" %} Borrow'd. All rights reserved.</p>
+        {% endblock %}
+    </div>
+</body>
+</html>

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -42,6 +43,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "pillow", specifier = ">=11.1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
+    { name = "typing-extensions", specifier = ">=4.13.2" },
 ]
 
 [[package]]
@@ -228,6 +230,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adding support for sending group invites via email/notifications system by adding an email input/form to the group invites page and support form submission group invites view to send emails. The view supports sending invites to multiple email addresses, but the template currently only shows one email input for now. Successful sharing reloads the page with a success message (as opposed to redirecting back to the group details page).

There aren't many checks right now on sending the emails (e.g. is the email address already associated with a user in the group? have they recently been sent an email? etc..). I was debating create a separate model to track sent invitations and send the email as a post-save signal, but that seemed like overkill right now and probably overly complex.

Also, added a debug launch configuration for VS Code users.