### PR TITLE
Add my lends and my borrows to profile page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v1.15.0
     hooks:
     -   id: mypy
-        args: [--strict]
+        args: [--strict, --python-version=3.13]
         additional_dependencies: [
             pytest==8.3.3,
             sqlalchemy==2.0.36,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Django",
+            "type": "debugpy",
+            "request": "launch",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "autoStartBrowser": false,
+            "program": "${workspaceFolder}/manage.py"
+        }
+    ]
+}

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -388,3 +388,35 @@ class Transaction(Model):
         related_name="+",  # No reverse relation needed
         help_text="The User who last updated the Transaction.",
     )
+
+    @staticmethod
+    def get_current_lends_for_user(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns the Items that are currently loaned to others by the given User.
+        """
+        return Transaction.objects.filter(
+            Q(party1=user)
+            & ~Q(
+                status__in=[
+                    TransactionStatus.RETURNED,
+                    TransactionStatus.REJECTED,
+                    TransactionStatus.CANCELLED,
+                ]
+            )
+        )
+
+    @staticmethod
+    def get_current_borrows_for_user(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns the Items the given User is currently borrowing from others.
+        """
+        return Transaction.objects.filter(
+            Q(party2=user)
+            & ~Q(
+                status__in=[
+                    TransactionStatus.RETURNED,
+                    TransactionStatus.REJECTED,
+                    TransactionStatus.CANCELLED,
+                ]
+            )
+        )

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -390,19 +390,45 @@ class Transaction(Model):
     )
 
     @staticmethod
-    def get_current_lends_for_user(user: BorrowdUser) -> QuerySet["Transaction"]:
+    def get_pending_transactions_for_user(user: BorrowdUser) -> QuerySet["Transaction"]:
         """
-        Returns the Items that are currently loaned to others by the given User.
+        Returns all Transactions that are currently pending for the given User.
+        This includes both requests to borrow Items and requests from the User
+        to borrow Items.
         """
         return Transaction.objects.filter(
-            Q(party1=user)
-            & ~Q(
+            Q(
                 status__in=[
-                    TransactionStatus.RETURNED,
-                    TransactionStatus.REJECTED,
-                    TransactionStatus.CANCELLED,
+                    TransactionStatus.REQUESTED,
+                    TransactionStatus.ACCEPTED,
                 ]
             )
+            # Considering transactions to confirm collection/return as pending requests also
+            | ~Q(updated_by=user)
+            & Q(
+                status__in=[
+                    TransactionStatus.COLLECTION_ASSERTED,
+                    TransactionStatus.RETURN_ASSERTED,
+                ]
+            )
+        )
+
+    @staticmethod
+    def get_borrow_requests_to_user(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns other Users' requests to the given User to borrow Items.
+        """
+        return Transaction.get_pending_transactions_for_user(user).filter(
+            Q(party1=user)
+        )
+
+    @staticmethod
+    def get_borrow_requests_from_user(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns requests from the given User to borrow from others.
+        """
+        return Transaction.get_pending_transactions_for_user(user).filter(
+            Q(party2=user)
         )
 
     @staticmethod
@@ -412,9 +438,14 @@ class Transaction(Model):
         """
         return Transaction.objects.filter(
             Q(party2=user)
+            # We could query on item__status=BORROWED, however in that case items marked 'Collection Asserted'
+            # would not appear as Borrowed until they were confirmed/marked as colledted by both parties
             & ~Q(
                 status__in=[
                     TransactionStatus.RETURNED,
+                    TransactionStatus.REQUESTED,
+                    # only considering it "Borrowed" once it has been collected, not just accepted
+                    TransactionStatus.ACCEPTED,
                     TransactionStatus.REJECTED,
                     TransactionStatus.CANCELLED,
                 ]

--- a/borrowd_users/models.py
+++ b/borrowd_users/models.py
@@ -17,6 +17,9 @@ class BorrowdUser(AbstractUser, BorrowdGroupPermissionMixin, GuardianUserMixin):
         through="borrowd_groups.Membership",
     )
 
+    # Hint for mypy (actual field created from reverse relation)
+    profile: "Profile"
+
 
 class Profile(models.Model):
     user: models.OneToOneField[BorrowdUser] = models.OneToOneField(

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -23,17 +23,20 @@ def profile_view(request: HttpRequest) -> HttpResponse:
     user: BorrowdUser = request.user  # type: ignore[assignment]
     profile = user.profile
 
-    user_items = Item.objects.filter(owner=user)
-    lends = Transaction.get_current_lends_for_user(user)
+    requests_from_user = Transaction.get_borrow_requests_from_user(user)
+    requests_to_user = Transaction.get_borrow_requests_to_user(user)
     borrows = Transaction.get_current_borrows_for_user(user)
+    user_items = Item.objects.filter(owner=user)
+
     return render(
         request,
         "users/profile.html",
         {
             "profile": profile,
-            "user_items": user_items,
-            "lends": lends,
+            "requests_from_user": requests_from_user,
+            "requests_to_user": requests_to_user,
             "borrows": borrows,
+            "user_items": user_items,
         },
     )
 

--- a/templates/components/items/item_box.html
+++ b/templates/components/items/item_box.html
@@ -1,6 +1,6 @@
 {% load static %}
 
-<a href="{% url 'item-detail' item.pk %}" class="block no-underline">
+<a href="{% url 'item-detail' pk %}" class="block no-underline">
     {% with box_size=box_size|default:'md' %} {# Define box_size with a default #}
     <div class="bg-gray-100 shadow-md rounded-lg hover:-translate-y-2 transition-all duration-300 ease-in-out
         {% if box_size == 'sm' %}
@@ -13,16 +13,16 @@
     ">
         <div class="relative w-full h-full">
             <!-- todo: map default images by item category (will require comprehensive default category images) -->
-            <img src="{{ item.photos.all.0.image.url|default:'/static/items/categories/logo-tools.png' }}" class="w-full h-1/2 object-cover" alt="{{ item.name|default:'Default item image' }}" />
+            <img src="{{ image|default:'/static/items/categories/logo-tools.png' }}" class="w-full h-1/2 object-cover" alt="{{ name|default:'Default item image' }}" />
             <div class="flex flex-col py-4 px-3">
                 <!-- todo: deal with super long names -->
-                <div class="text-lg font-bold">{{item.name}}</div>
-                <div class="text-sm text-gray-500">Owned by {{ item.owner.username }}</div>
+                <div class="text-lg font-bold">{{name}}</div>
+                <div class="text-sm text-gray-500">Owned by {{ owner }}</div>
             </div>
             <!-- todo: chip component -->
             <div class="absolute bottom-0 right-0 m-2">
                 <!-- todo: request/borrow/action flow -->
-                <div class="bg-green-400 rounded-2xl px-2 text-sm">{{item.get_status_display}}</div>
+                <div class="bg-green-400 rounded-2xl px-2 text-sm">{{status}}</div>
             </div>
         </div>
     </div>

--- a/templates/components/items/item_box.html
+++ b/templates/components/items/item_box.html
@@ -22,7 +22,7 @@
             <!-- todo: chip component -->
             <div class="absolute bottom-0 right-0 m-2">
                 <!-- todo: request/borrow/action flow -->
-                <div class="bg-green-400 rounded-2xl px-2 text-sm">{{status}}</div>
+                <div class="bg-green-400 rounded-2xl px-2 text-sm">{{ status }}</div>
             </div>
         </div>
     </div>

--- a/templates/components/items/item_grid.html
+++ b/templates/components/items/item_grid.html
@@ -1,0 +1,27 @@
+<div class="{{ class }}">
+    {% if title %}
+        <c-h2>{{title}}</c-h2>
+    {% endif %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
+    {% for item in items %}
+        {% load static %}
+        <c-items.item-box pk="{{item.pk}}"
+            name="{{item.name}}"
+            owner="{{item.owner.username}}"
+            status="{{item.get_status_display}}"
+            image="{{item.photos.all.0.image.url}}"
+            box_size="{{ box_size }}"
+        />
+    {% endfor %}
+    {% for tx in transactions %}
+        {% load static %}
+        <c-items.item-box pk="{{ tx.item.pk }}"
+            name="{{ tx.item.name }}"
+            owner="{{ tx.item.owner.username }}"
+            image="{{ tx.item.photos.all.0.image.url }}"
+            status="{{ tx.get_status_display }}"
+            box_size="{{ box_size }}"
+        />
+    {% endfor %}
+    </div>
+</div>

--- a/templates/components/items/item_grid.html
+++ b/templates/components/items/item_grid.html
@@ -3,6 +3,11 @@
         <c-h2>{{title}}</c-h2>
     {% endif %}
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
+    {% if not items and not transactions %}
+        <div class="col-span-full text-gray-500 py-4 pl-4">
+            <p>Nothing here yet</p>
+        </div>
+    {% endif %}
     {% for item in items %}
         {% load static %}
         <c-items.item-box pk="{{item.pk}}"

--- a/templates/items/item_list.html
+++ b/templates/items/item_list.html
@@ -45,13 +45,7 @@
             </div>
         </form>
         <c-divider />
-        <div class="flex flex-col space-y-4 mt-6">
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 place-items-center">
-                {% for item in item_list %}
-                <c-items.item-box :item="{{ item }}" />
-                {% endfor %}
-            </div>
-        </div>
+        <c-items.item-grid :items="item_list" class="flex flex-col space-y-4 mt-6" />
     </c-box>
 </div>
 {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -6,10 +6,11 @@
 {% block content %}
 <div class="flex flex-col space-y-4 bg-white shadow-lg rounded-lg p-8 w-full max-w-2xl">
     <c-profile-card :profile="profile" />
-    <!-- User's Items -->
+
+    <c-items.item-grid title='My Requests' :transactions="requests_from_user" box_size="sm" />
+    <c-items.item-grid title='Requests for Me' :transactions="requests_to_user" box_size="sm" />
+    <c-items.item-grid title='Borrowed' :transactions="borrows" box_size="sm" />
     <c-items.item-grid title='My Items' :items="user_items" box_size="sm" />
-    <c-items.item-grid title='My Lends' :transactions="lends" box_size="sm" />
-    <c-items.item-grid title='My Borrows' :transactions="borrows" box_size="sm" />
     <!-- Settings Section -->
     <div class="mt-6">
         <c-h2>{% trans "Settings" %}</c-h2>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -7,15 +7,9 @@
 <div class="flex flex-col space-y-4 bg-white shadow-lg rounded-lg p-8 w-full max-w-2xl">
     <c-profile-card :profile="profile" />
     <!-- User's Items -->
-    <div>
-        <c-h2>Your Items</c-h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
-        {% for item in user_items %}
-            {% load static %}
-            <c-items.item-box :item="{{ item }}" box_size='sm' />
-        {% endfor %}
-        </div>
-    </div>
+    <c-items.item-grid title='My Items' :items="user_items" box_size="sm" />
+    <c-items.item-grid title='My Lends' :transactions="lends" box_size="sm" />
+    <c-items.item-grid title='My Borrows' :transactions="borrows" box_size="sm" />
     <!-- Settings Section -->
     <div class="mt-6">
         <c-h2>{% trans "Settings" %}</c-h2>


### PR DESCRIPTION
Rendering pending borrowing requests (to and from) in addition to borrowed and owned items in profile page

Notes
- fixing python version to 3.13 to avoid mypy complaints about not importing from 'typing_extensions' package
- add vs code launch config
- cleaning up some mypy issues around user and profile typing
- add pending transactions and borrowed items query methods to Transaction model
- creating shared item grid component to handle items and transactions (showing items involved in borrow transactions)
- reuse item-grid on item listing and profile page
- refactoring item-box to take direct parameters as opposed to an item object parameter to support rendering items from transactions. django-cotton does not seem to allow passing in related models without uglier hacks (the related models are converted to their string representations instead of full objects)