### PR TITLE
Bugfix: remove Item permissions from Group when User leaves.

### DIFF
--- a/borrowd_groups/signals.py
+++ b/borrowd_groups/signals.py
@@ -135,7 +135,7 @@ def pre_membership_delete(
     _raise_if_last_moderator(user, group, **kwargs)
 
     #
-    # Handle permissions removal
+    # Handle Group removal
     #
     all_perms = [
         "view_this_group",
@@ -145,6 +145,13 @@ def pre_membership_delete(
     # Remove all permissions for the user on the group
     for perm in all_perms:
         remove_perm(perm, user, group)
+
+    #
+    # Handle Item removal
+    #
+    items_of_user = Item.objects.filter(owner=user)
+    for perm in ["view_this_item"]:  # will have more later
+        remove_perm(perm, group, items_of_user)
 
 
 @receiver(pre_save, sender=Membership)

--- a/tests/test_group_based_item_permissions.py
+++ b/tests/test_group_based_item_permissions.py
@@ -152,6 +152,35 @@ class GroupBasedItemPermissionsTests(TestCase):
         ## Check if the group member can still see the item
         self.assertFalse(member.has_perm("view_this_item", item))
 
+    def test_item_not_visible_to_group_owner_on_leaving_group(self) -> None:
+        # Arrange
+        moderator = self.owner
+        member = self.member
+
+        ## Create a group
+        group: BorrowdGroup = BorrowdGroup.objects.create(
+            name="Test Group", created_by=moderator, updated_by=moderator
+        )
+
+        ## Create an item, owned by *Member*
+        item = Item.objects.create(
+            name="Test Item", owner=member, trust_level_required=TrustLevel.LOW
+        )
+
+        # Act
+        ## Add the member to the group
+        group.add_user(member, trust_level=TrustLevel.LOW)
+
+        # Assert
+        ## Check if the group Moderator can see the item
+        self.assertTrue(moderator.has_perm("view_this_item", item))
+
+        ## Remove the member from the group
+        group.remove_user(member)
+
+        ## Confirm the group Moderator can no longer see the item
+        self.assertFalse(moderator.has_perm("view_this_item", item))
+
     def test_item_not_visible_to_non_members(self) -> None:
         # Arrange
         owner = self.owner


### PR DESCRIPTION
Fixes #90.

Can one ever _really_ have enough tests?

Turns out swapping the borrower and the lender for one of our existing tests changed the outcome.

New test added, and fix implemented.