### PR TITLE
Group listing: proper group trust level.

### DIFF
--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -229,9 +229,9 @@ class GroupJoinView(LoginRequiredMixin, View):
 
 
 # No typing for django_filter, so mypy doesn't like us subclassing.
-class GroupListView(BorrowdTemplateFinderMixin, FilterView):  # type: ignore[misc]
-    model = BorrowdGroup
-    template_name_suffix = "_list"  # Reusing template from ListView
+class GroupListView(FilterView):  # type: ignore[misc]
+    template_name = "groups/group_list.html"
+    model = Membership
     filterset_class = GroupFilter
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,24 @@
         tailwind.config = {
             theme: {
                 extend: {
+                    colors: {
+                        "borrowd-indigo": {
+                            300: "#d9e1f4",
+                            600: "#2c51a1",
+                        },
+                        "borrowd-honey": {
+                            300: "#fdf7e1",
+                            600: "#b97c21",
+                        },
+                        "borrowd-plum": {
+                            300: "#f0d7eb",
+                            600: "#73325b",
+                        },
+                        "borrowd-fern": {
+                            300: "#ebf7ed",
+                            600: "#537533",
+                        },
+                    },
                     fontFamily: {
                         'roboto-slab': ['"Roboto Slab"', 'serif'],
                     },

--- a/templates/components/trust_pill.html
+++ b/templates/components/trust_pill.html
@@ -1,0 +1,27 @@
+{% if level|lower == 'high' %}
+<span class="px-2 inline-flex text-xs
+    leading-5 font-semibold rounded-full
+    bg-borrowd-fern-300
+    text-borrowd-fern-600">
+{% elif level|lower == 'medium' %}
+<span class="px-2 inline-flex text-xs
+    leading-5 font-semibold rounded-full
+    bg-borrowd-honey-300
+    text-borrowd-honey-600">
+{% elif level|lower == 'low' %}
+<span class="px-2 inline-flex text-xs
+    leading-5 font-semibold rounded-full
+    bg-borrowd-plum-300
+    text-borrowd-plum-600">
+{% else %}
+<span class="px-2 inline-flex text-xs
+    leading-5 font-semibold rounded-full
+    bg-borrowd-indigo-300
+    text-borrowd-indigo-600">
+{% endif %}
+    {% if slot %}
+        {{ slot }}
+    {% else %}
+        {{ level }}
+    {% endif %}
+</span>

--- a/templates/groups/group_list.html
+++ b/templates/groups/group_list.html
@@ -51,30 +51,32 @@
                             </tr>
                         </thead>
                         <tbody class="bg-white divide-y divide-gray-200">
-                            {% for group in borrowdgroup_list %}
+                            {% for membership in object_list %}
                                 <tr>
                                     <td class="px-6 py-4 whitespace-nowrap">
                                         <div class="flex items-center">
-                                            {% if group.logo %}
+                                            {% if membership.group.logo %}
                                                 <div class="flex-shrink-0 h-10 w-10">
-                                                    <img class="h-10 w-10 rounded-full object-cover" src="{{ group.logo.url }}" alt="{{ group.name }} Logo">
+                                                    <img class="h-10 w-10 rounded-full object-cover"
+                                                        src="{{ membership.group.logo.url }}"
+                                                        alt="{{ membership.group.name }} Logo">
                                                 </div>
                                             {% endif %}
                                             <div class="ml-4">
                                                 <div class="text-sm font-medium text-gray-900">
-                                                    <a class="hover:underline text-blue-800" href="{% url 'borrowd_groups:group-detail' group.pk %}">{{ group.name }}</a>
+                                                    <a class="hover:underline text-blue-800"
+                                                        href="{% url 'borrowd_groups:group-detail' membership.group.pk %}">
+                                                        {{ membership.group.name }}
+                                                    </a>
                                                 </div>
                                             </div>
                                         </div>
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap">
-                                        {# TODO: This is hardcoded for now, needs to be updated to display the actual trust level #}
-                                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                                            High
-                                        </span>
+                                        <c-trust-pill level="{{ membership.get_trust_level_display }}" />
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                        {{ group.users.count }}
+                                        {{ membership.group.users.count }}
                                     </td>
                                 </tr>
                             {% empty %}


### PR DESCRIPTION
Closes #92.

This commit makes it so that one's proper Trust Level is reflected for each Group on the Group listing page.

Note that, in order to do this, the generic list view and filter used for that page are now based on the Membership model, _not_ the Group model itself any longer. This is because the Trust Level is a property of a User's _relationship_ with the Group, as captured in the Membership through-model, rather than of the Group itself.

Note also that despite this change, the View class, Filter class and template naming still refer to "Group" rather than switching everything to "Membership". This reflects where one would expect to find these components based on the app UI.

**Before:**
![image](https://github.com/user-attachments/assets/5c0e1a7f-f460-4bb6-a0f1-4f601d30cb4f)

**After:**
![image](https://github.com/user-attachments/assets/bc2e512f-96e9-4e54-9e94-f5034a03a92c)
