### PR TITLE
Set site's header to full width on all screens

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% load i18n %}
-<header class="flex justify-between items-center bg-white shadow-md p-4 pr-10 w-5xl mx-auto rounded-b-2xl">
+<header class="flex justify-between items-center bg-white shadow-md p-4 pr-10 w-full mx-auto rounded-b-2xl">
     <nav class="flex justify-between items-center w-full">
         <ul class="flex flex-col md:flex-row text-center my-auto md:space-x-8 items-center ml-5">
             {% if user.is_authenticated %}


### PR DESCRIPTION
Before 
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/25ac26fd-94c9-4240-8547-ba132720370d" />


After
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/92c6668a-e94b-4ce4-95ed-24e4494104cd" />
