### PR TITLE
120 add trust level setting to item create edit screen

### DIFF
--- a/borrowd_items/forms.py
+++ b/borrowd_items/forms.py
@@ -8,4 +8,4 @@ class ItemCreateWithPhotoForm(forms.ModelForm[Item]):
 
     class Meta:
         model = Item
-        fields = ["name", "description", "category"]
+        fields = ["name", "description", "category", "trust_level_required"]

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -91,6 +91,7 @@ class Item(Model):
     )
     trust_level_required: IntegerField[TrustLevel, int] = IntegerField(
         choices=TrustLevel,
+        default=TrustLevel.HIGH,
         help_text=(
             "The minimum required Group trust level required for"
             " this Item to be visible to and borrowable by members"

--- a/borrowd_items/signals.py
+++ b/borrowd_items/signals.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import Group
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from guardian.shortcuts import assign_perm
+from guardian.shortcuts import assign_perm, remove_perm
 
 from .models import Item
 
@@ -11,27 +11,34 @@ def assign_item_permissions(
     sender: Item, instance: Item, created: bool, **kwargs: str
 ) -> None:
     """
-    When a new Item is created, assign all relevant Item permissions
+    When a new Item is created or updated, assign all relevant Item permissions
     to the owner and relevant Groups.
     """
+    owner_borrowd_groups = instance.owner.borrowd_groups.all()  # type: ignore[attr-defined]
+    owner_groups = Group.objects.filter(
+        name__in=owner_borrowd_groups.values_list("name", flat=True)
+    )
+
     if created:
+        # For new items, assign owner permissions
         for perm in ["view_this_item", "edit_this_item", "delete_this_item"]:
             assign_perm(
                 perm,
                 instance.owner,
                 instance,
             )
+    else:
+        # For updated items, remove existing group permissions first
+        for group in owner_groups:
+            remove_perm("view_this_item", group, instance)
 
-        # Assign view permissions to all Groups of which the owner
-        # is a member and has an equal or greater Trust Level than
-        # the level required by this Item.
-        # mypy struggling a bit here again, even though intellisense
-        # knows that Item.owner (BorrowedUser) does indeed have a
-        # a Groups accessor.
-        allowed_borrowd_groups = instance.owner.borrowd_groups.filter(  # type: ignore[attr-defined]
-            membership__trust_level__gte=instance.trust_level_required
-        )
-        allowed_groups = Group.objects.filter(
-            name__in=allowed_borrowd_groups.values_list("name", flat=True)
-        )
-        assign_perm("view_this_item", allowed_groups, instance)
+    # Assign view permissions to all Groups of which the owner
+    # is a member and has an equal or greater Trust Level than
+    # the level required by this Item.
+    allowed_borrowd_groups = owner_borrowd_groups.filter(
+        membership__trust_level__gte=instance.trust_level_required
+    )
+    allowed_groups = owner_groups.filter(
+        name__in=allowed_borrowd_groups.values_list("name", flat=True)
+    )
+    assign_perm("view_this_item", allowed_groups, instance)

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -13,7 +13,6 @@ from django.views.generic import (
 )
 from django_filters.views import FilterView
 
-from borrowd.models import TrustLevel
 from borrowd.util import BorrowdTemplateFinderMixin
 from borrowd_users.models import BorrowdUser
 
@@ -103,8 +102,6 @@ class ItemCreateView(
 
     def form_valid(self, form: ItemCreateWithPhotoForm) -> HttpResponse:
         form.instance.owner = self.request.user  # type: ignore[assignment]
-        # default trust level for now
-        form.instance.trust_level_required = TrustLevel.LOW
         response = super().form_valid(form)
         image = form.cleaned_data.get("image")
         if image:
@@ -142,7 +139,7 @@ class ItemListView(BorrowdTemplateFinderMixin, FilterView):  # type: ignore[misc
 
 class ItemUpdateView(BorrowdTemplateFinderMixin, UpdateView[Item, ModelForm[Item]]):
     model = Item
-    fields = ["name", "description", "category"]
+    fields = ["name", "description", "category", "trust_level_required"]
 
     def get_success_url(self) -> str:
         if self.object is None:

--- a/templates/items/item_detail.html
+++ b/templates/items/item_detail.html
@@ -17,6 +17,13 @@
     </div>
     <div class="flex flex-col w-3/4 items-center">
         <c-h1>{{ object.name }}</c-h1>
+        {% if user.is_authenticated and object.owner == user %}
+        <div class="mb-2">
+            <c-trust-pill level="{{object.get_trust_level_required_display}}">
+                Trust Level: {{object.get_trust_level_required_display}}
+            </c-trust-pill>
+        </div>
+        {% endif %}
 
         <c-gallery>
             {% for photo in view.object.photos.all %}
@@ -29,7 +36,7 @@
             :action-context="action_context"
         ></c-items.action-buttons-with-status>
     </div>
-    <div class="flex flex-col bg-borrowd-indigo-300/50 p-4 rounded-lg">
+    <div class="flex flex-col bg-borrowd-indigo-300/50 p-4 rounded-lg w-full">
         <c-h2>Description</c-h2>
         <p>{{ object.description }}</p>
     </div>


### PR DESCRIPTION
Adds the ability to update Item trust level and accordingly updates view permissions for user's groups

## Before
<img width="1329" height="709" alt="image" src="https://github.com/user-attachments/assets/f30eaec1-f150-4d93-84f4-9475f4239f94" />


## After
<img width="1326" height="718" alt="image" src="https://github.com/user-attachments/assets/ac2fab81-f552-4633-afa8-823c24684c76" />
