### PR TITLE
Group permissions: basic approach

### DIFF
--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -140,6 +140,13 @@ LOGIN_REDIRECT_URL = reverse_lazy("item-list")
 
 ACCOUNT_LOGIN_BY_CODE_ENABLED = True
 
+# Render template rather than simply returning 403 status code with
+# no content
+GUARDIAN_RENDER_403 = True
+# Don't create the user named AnonymousUser. We don't need to give
+# object-level permisions to logged-out users, so reduce complexity.
+ANONYMOUS_USER_NAME = None
+
 # django-allauth configurations
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",

--- a/borrowd_groups/templates/403.html
+++ b/borrowd_groups/templates/403.html
@@ -1,0 +1,9 @@
+{% extends "groups/layout.html" %}
+{% block head_title %}Group Access Denied{% endblock %}
+
+{% block groups_content %}
+<c-box>
+<p>You cannot currently access this group.</p>
+<p>Try asking a member of the group for an invitation!</p>
+</c-box>
+{% endblock %}

--- a/borrowd_groups/tests/test_group_detail_view.py
+++ b/borrowd_groups/tests/test_group_detail_view.py
@@ -1,0 +1,111 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+
+from borrowd.models import TrustLevel
+from borrowd_groups.models import BorrowdGroup
+from borrowd_groups.views import GroupDetailView
+from borrowd_users.models import BorrowdUser
+
+
+class GroupDetailViewTests(TestCase):
+    def setUp(self) -> None:
+        self.member = BorrowdUser.objects.create(
+            username="member", email="member@example.com"
+        )
+        self.owner = BorrowdUser.objects.create(
+            username="owner", email="owner@example.com"
+        )
+        self.factory = RequestFactory()
+
+    def test_group_member_can_view_detail_page(self) -> None:
+        #
+        #  Arrange
+        #
+
+        ## Get Users
+        owner = self.owner
+
+        ## Create Group
+        group = BorrowdGroup.objects.create(
+            name="Test Group",
+            created_by=owner,
+            updated_by=owner,
+            trust_level=TrustLevel.HIGH,
+        )
+
+        ## Preare the request
+        request = self.factory.get(f"/groups/{group.pk}")
+        request.user = owner
+
+        #
+        # Act
+        #
+        response = GroupDetailView.as_view()(request, pk=group.pk)
+
+        #
+        #  Assert
+        #
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_non_member_cannot_view_detail_page(self) -> None:
+        #
+        #  Arrange
+        #
+
+        ## Get Users
+        owner = self.owner
+        another = self.member
+
+        ## Create Group
+        group = BorrowdGroup.objects.create(
+            name="Test Group",
+            created_by=owner,
+            updated_by=owner,
+            trust_level=TrustLevel.HIGH,
+        )
+
+        ## Preare the request
+        request = self.factory.get(f"/groups/{group.pk}")
+        request.user = another
+
+        #
+        # Act
+        #
+        response = GroupDetailView.as_view()(request, pk=group.pk)
+
+        #
+        #  Assert
+        #
+        # Forbidden error
+        self.assertEqual(response.status_code, 403)
+
+    def test_logged_out_user_cannot_view_detail_page(self) -> None:
+        #
+        #  Arrange
+        #
+
+        ## Get Users
+        owner = self.owner
+
+        ## Create Group
+        group = BorrowdGroup.objects.create(
+            name="Test Group",
+            created_by=owner,
+            updated_by=owner,
+            trust_level=TrustLevel.HIGH,
+        )
+
+        ## Preare the request
+        request = self.factory.get(f"/groups/{group.pk}")
+        request.user = AnonymousUser()
+
+        #
+        # Act
+        #
+        response = GroupDetailView.as_view()(request, pk=group.pk)
+
+        #
+        #  Assert
+        #
+        # Redirect to login page
+        self.assertEqual(response.status_code, 302)

--- a/borrowd_groups/urls.py
+++ b/borrowd_groups/urls.py
@@ -21,3 +21,5 @@ urlpatterns = [
     path("<int:pk>/delete/", GroupDeleteView.as_view(), name="group-delete"),
     path("join/<str:encoded>/", GroupJoinView.as_view(), name="group-join"),
 ]
+
+handler403 = "borrowd_groups.views.forbidden"

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -63,7 +63,7 @@ class GroupCreateView(
 
     def form_valid(self, form: ModelForm[BorrowdGroup]) -> HttpResponse:
         if self.request.user.is_authenticated:
-            form.instance.created_by_id = form.instance.updated_by_id = (
+            form.instance.created_by_id = form.instance.updated_by_id = (  # type: ignore[attr-defined]
                 self.request.user.pk
             )
 
@@ -140,7 +140,8 @@ class GroupInviteView(DetailView[BorrowdGroup]):
         return context
 
 
-class GroupJoinView(LoginRequiredMixin, View):
+# No typing for django_guardian, so mypy doesn't like us subclassing.
+class GroupJoinView(LoginRequiredMixin, View):  # type: ignore[misc]
     """
     View to handle group join requests via invite link.
 
@@ -185,7 +186,7 @@ class GroupJoinView(LoginRequiredMixin, View):
             # returning a `Group` and not a `BorrowdGroup`?
             group = BorrowdGroup.objects.get(
                 pk=group_invite.group_id, name=group_invite.group_name
-            )  # type: ignore[assignment]
+            )
         except (BorrowdGroup.DoesNotExist, ValueError):
             # Don't reveal any info about Group lookup
             err = "invalid"
@@ -252,7 +253,7 @@ class GroupUpdateView(
 
     def form_valid(self, form: ModelForm[BorrowdGroup]) -> HttpResponse:
         if self.request.user.is_authenticated:
-            form.instance.updated_by_id = self.request.user.pk
+            form.instance.updated_by_id = self.request.user.pk  # type: ignore[attr-defined]
         return super().form_valid(form)
 
     def get_success_url(self) -> str:

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.signing import SignatureExpired, TimestampSigner
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
@@ -18,6 +17,7 @@ from django.views.generic import (
     View,
 )
 from django_filters.views import FilterView
+from guardian.mixins import LoginRequiredMixin, PermissionRequiredMixin
 
 from borrowd.util import BorrowdTemplateFinderMixin
 
@@ -88,8 +88,16 @@ class GroupDeleteView(
     success_url = reverse_lazy("borrowd_groups:group-list")
 
 
-class GroupDetailView(BorrowdTemplateFinderMixin, DetailView[BorrowdGroup]):
+# No typing for django_guardian, so mypy doesn't like us subclassing.
+class GroupDetailView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    PermissionRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    DetailView[BorrowdGroup],
+):
     model = BorrowdGroup
+    permission_required = "view_this_group"
+    return_403 = True
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -8,6 +8,7 @@ from django.core.signing import SignatureExpired, TimestampSigner
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
+from django.template import loader as template_loader
 from django.urls import reverse, reverse_lazy
 from django.views.generic import (
     CreateView,
@@ -250,3 +251,9 @@ class GroupUpdateView(
         if self.object is None:
             return reverse("borrowd_groups:group-list")
         return reverse("borrowd_groups:group-detail", args=[self.object.pk])
+
+
+def forbidden(request: HttpRequest) -> HttpResponse:
+    template = template_loader.get_template("./templates/403.html")
+    body = template.render
+    return HttpResponse(body, status=403)


### PR DESCRIPTION
This small PR demonstrates the general approach for locking down Views with object-level / record-level permissions as provided by Django Guardian.

Currently only implemented for the Group Detail view.

TODO:

- Create view
- Delete view
- Invite view
- List view 
- Update view

Implementing the above should now be more straightforward, following the patterns established in this PR.

Note the Join view was already using LoginRequiredMixin.

Work summary:

*    New (basic) custom template for 403 errors for Groups.
    
    Perhaps will want to make this generic across the app and simply pass
    in object-type-specific error messages as context. But this works for
    now.

*    Update django_guardian configs (403, Anonymous User).
    
    Prep for using View auth mixins from Django Guardian:
    
    * Render a 403 template instead of just returning a 403 code with no
      content.
    * Stop django_guardian creating an AnonymousUser in the database. We
      don't need to give object-level perms to non-logged-in users, and
      this is a moderately surprising deviation from core Django's way of
      handling anonymous users, so let's just avoid surprises and
      complexity. This came up whilst debugging a test which appeared not
      to have been behaving correctly, due to using DG's
      `get_anonymous_user()` instead of Django's default `AnonymousUser`
      class from core auth contrib.

*    Groups: Create and use custom handler view for 403s.

*    Apply permissions to Group detail view.
    
    * Logged out users: redirect to login page
    * Logged-in, non-members: (friendly) 403 error page

*    Tests for permissioning around Group detail view
*    Some extra typing exclusions required by mypy.