### PR TITLE
Fix test suite

### DIFF
--- a/borrowd_groups/signals.py
+++ b/borrowd_groups/signals.py
@@ -152,6 +152,8 @@ def pre_membership_delete(
     membership = instance
     user: BorrowdUser = membership.user  # type: ignore[assignment]
     borrowd_group: BorrowdGroup = membership.group  # type: ignore[assignment]
+    # error: "_ST" has no attribute "name"  [attr-defined]
+    group = Group.objects.get(name=borrowd_group.name)
 
     #
     # Check the group will not be left without a Moderator

--- a/tests/test_borrowing_flows.py
+++ b/tests/test_borrowing_flows.py
@@ -104,7 +104,7 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        item_actions = response.context_data["item_actions"]
+        item_actions = response.context_data["action_context"].actions
 
         #
         # Assert
@@ -139,7 +139,7 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        item_actions = response.context_data["item_actions"]
+        item_actions = response.context_data["action_context"].actions
 
         #
         # Assert
@@ -211,7 +211,7 @@ class RejectedFlowTest(SimpleTestCase):
         # mypy doesn't know that.
         if not hasattr(response, "context_data"):
             self.fail("Response should have context_data")
-        item_actions = response.context_data["item_actions"]
+        item_actions = response.context_data["action_context"].actions
 
         #
         # Assert


### PR DESCRIPTION
Closes #144.

Some tests had become broken over time... mostly by me :eyes: 

This gets us clean again test-wise, setting us up for automatically running tests as part of a CI/CD process.