### PR TITLE
ability to disable borrowd_beta

### DIFF
--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -202,6 +202,7 @@ MEDIA_URL = "/media/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # borrowd_beta settings
+BORROWD_BETA_ENABLED = env("BORROWD_BETA_ENABLED", default=True)
 BETA_SIGNUP_REDIRECT_PATH = "/"
 BETA_CHECK_EXCLUDE_PATHS = [
     r"^/favicon.ico$",

--- a/borrowd_beta/context_processors.py
+++ b/borrowd_beta/context_processors.py
@@ -1,14 +1,17 @@
 from typing import Any
 
+from django.conf import settings
 from django.http import HttpRequest
 
 from borrowd_beta.forms import BetaSignupForm
 
 
 def beta_status(request: HttpRequest) -> dict[str, Any]:
-    has_beta_access = getattr(request, "has_beta_access", False)
-
-    return {
-        "has_beta_access": has_beta_access,
-        "beta_signup_form": None if has_beta_access else BetaSignupForm(),
-    }
+    if settings.BORROWD_BETA_ENABLED:
+        has_beta_access = getattr(request, "has_beta_access", False)
+        return {
+            "has_beta_access": has_beta_access,
+            "beta_signup_form": None if has_beta_access else BetaSignupForm(),
+        }
+    else:
+        return {"has_beta_access": True, "beta_signup_form": None}


### PR DESCRIPTION
Added a flag allowing us to disable borrowd_beta locally (and, eventually, on the live site). In order to use it, add the following to your local .env file:

```
BORROWD_BETA_ENABLED=False
```
