### PR TITLE
make all views require login

### DIFF
--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -9,13 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.template import loader as template_loader
 from django.urls import reverse, reverse_lazy
-from django.views.generic import (
-    CreateView,
-    DeleteView,
-    DetailView,
-    UpdateView,
-    View,
-)
+from django.views.generic import CreateView, DeleteView, DetailView, UpdateView, View
 from django_filters.views import FilterView
 from guardian.mixins import LoginRequiredMixin, PermissionRequiredMixin
 
@@ -57,7 +51,9 @@ class InviteSigner:
 
 
 class GroupCreateView(
-    BorrowdTemplateFinderMixin, CreateView[BorrowdGroup, ModelForm[BorrowdGroup]]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    CreateView[BorrowdGroup, ModelForm[BorrowdGroup]],
 ):
     model = BorrowdGroup
     form_class = GroupCreateForm
@@ -82,7 +78,9 @@ class GroupCreateView(
 
 
 class GroupDeleteView(
-    BorrowdTemplateFinderMixin, DeleteView[BorrowdGroup, ModelForm[BorrowdGroup]]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    DeleteView[BorrowdGroup, ModelForm[BorrowdGroup]],
 ):
     # Todo: prevent non-admin/moderators from completing this action
     model = BorrowdGroup
@@ -126,7 +124,10 @@ class GroupDetailView(
 
 
 # TODO: secure to Group members (not just logged-in users)
-class GroupInviteView(DetailView[BorrowdGroup]):
+class GroupInviteView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    DetailView[BorrowdGroup],
+):
     model = BorrowdGroup
     template_name = "groups/group_invite.html"
 
@@ -239,14 +240,16 @@ class GroupJoinView(LoginRequiredMixin, View):  # type: ignore[misc]
 
 
 # No typing for django_filter, so mypy doesn't like us subclassing.
-class GroupListView(FilterView):  # type: ignore[misc]
+class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
     template_name = "groups/group_list.html"
     model = Membership
     filterset_class = GroupFilter
 
 
 class GroupUpdateView(
-    BorrowdTemplateFinderMixin, UpdateView[BorrowdGroup, ModelForm[BorrowdGroup]]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    UpdateView[BorrowdGroup, ModelForm[BorrowdGroup]],
 ):
     model = BorrowdGroup
     fields = ["name", "description", "logo", "banner", "membership_requires_approval"]

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -5,13 +5,9 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse, reverse_lazy
 from django.views.decorators.http import require_POST
-from django.views.generic import (
-    CreateView,
-    DeleteView,
-    DetailView,
-    UpdateView,
-)
+from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 from django_filters.views import FilterView
+from guardian.mixins import LoginRequiredMixin
 
 from borrowd.util import BorrowdTemplateFinderMixin
 from borrowd_users.models import BorrowdUser
@@ -120,7 +116,9 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
 
 
 class ItemCreateView(
-    BorrowdTemplateFinderMixin, CreateView[Item, ItemCreateWithPhotoForm]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    CreateView[Item, ItemCreateWithPhotoForm],
 ):
     model = Item
     form_class = ItemCreateWithPhotoForm
@@ -139,12 +137,20 @@ class ItemCreateView(
         return reverse("item-detail", args=[self.object.pk])
 
 
-class ItemDeleteView(BorrowdTemplateFinderMixin, DeleteView[Item, ModelForm[Item]]):
+class ItemDeleteView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    DeleteView[Item, ModelForm[Item]],
+):
     model = Item
     success_url = reverse_lazy("item-list")
 
 
-class ItemDetailView(BorrowdTemplateFinderMixin, DetailView[Item]):
+class ItemDetailView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    DetailView[Item],
+):
     model = Item
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
@@ -156,13 +162,21 @@ class ItemDetailView(BorrowdTemplateFinderMixin, DetailView[Item]):
 
 
 # No typing for django_filter, so mypy doesn't like us subclassing.
-class ItemListView(BorrowdTemplateFinderMixin, FilterView):  # type: ignore[misc]
+class ItemListView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    FilterView,  # type: ignore[misc]
+):
     model = Item
     template_name_suffix = "_list"  # Reusing template from ListView
     filterset_class = ItemFilter
 
 
-class ItemUpdateView(BorrowdTemplateFinderMixin, UpdateView[Item, ItemForm]):
+class ItemUpdateView(
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    UpdateView[Item, ItemForm],
+):
     model = Item
     form_class = ItemForm
 
@@ -173,7 +187,9 @@ class ItemUpdateView(BorrowdTemplateFinderMixin, UpdateView[Item, ItemForm]):
 
 
 class ItemPhotoCreateView(
-    BorrowdTemplateFinderMixin, CreateView[ItemPhoto, ModelForm[ItemPhoto]]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    CreateView[ItemPhoto, ModelForm[ItemPhoto]],
 ):
     model = ItemPhoto
     fields = ["image"]  # item set from URL params
@@ -197,7 +213,9 @@ class ItemPhotoCreateView(
 
 
 class ItemPhotoDeleteView(
-    BorrowdTemplateFinderMixin, DeleteView[ItemPhoto, ModelForm[ItemPhoto]]
+    LoginRequiredMixin,  # type: ignore[misc]
+    BorrowdTemplateFinderMixin,
+    DeleteView[ItemPhoto, ModelForm[ItemPhoto]],
 ):
     model = ItemPhoto
 


### PR DESCRIPTION
Before this change, when a user would go to /items/ before they were logged in, they would see a 500. This is because that view did not require a user to be logged in to access it, but did require a user to be logged in to function. After this change, all views require a logged in user, and the 500 errors at /items/ and /groups/ have been solved.