### PR TITLE
Pass User's trust level of a group to the Detail page, let them update it

### DIFF
--- a/borrowd_groups/forms.py
+++ b/borrowd_groups/forms.py
@@ -30,3 +30,12 @@ class GroupJoinForm(forms.Form):
         required=True,
         label="Your Trust Level with this Group",
     )
+
+
+class UpdateTrustLevelForm(forms.Form):
+    trust_level = forms.ChoiceField(
+        choices=TrustLevel.choices,
+        required=True,
+        label="Your Trust Level with this Group",
+        help_text="Update your trust level to control what items you share with this group.",
+    )

--- a/borrowd_groups/urls.py
+++ b/borrowd_groups/urls.py
@@ -8,6 +8,7 @@ from .views import (
     GroupJoinView,
     GroupListView,
     GroupUpdateView,
+    UpdateTrustLevelView,
 )
 
 app_name = "borrowd_groups"
@@ -19,6 +20,11 @@ urlpatterns = [
     path("<int:pk>/invite/", GroupInviteView.as_view(), name="group-invite"),
     path("<int:pk>/edit/", GroupUpdateView.as_view(), name="group-edit"),
     path("<int:pk>/delete/", GroupDeleteView.as_view(), name="group-delete"),
+    path(
+        "<int:pk>/update-trust-level/",
+        UpdateTrustLevelView.as_view(),
+        name="update-trust-level",
+    ),
     path("join/<str:encoded>/", GroupJoinView.as_view(), name="group-join"),
 ]
 

--- a/templates/components/groups/trust_level_editor.html
+++ b/templates/components/groups/trust_level_editor.html
@@ -1,0 +1,39 @@
+<div x-data="{ editing: false, trustLevel: {{ trust_level }}, saving: false }" class="flex items-center gap-2">
+    <span class="text-sm text-gray-600">Your Trust Level:</span>
+
+    <div x-show="!editing" class="flex items-center gap-2">
+        <span x-text="trustLevel === 1 ? 'Low' : trustLevel === 2 ? 'Medium' : 'High'" class="text-sm font-medium text-gray-900"></span>
+        <c-trust-pill :level="trustLevel === 1 ? 'Low' : trustLevel === 2 ? 'Medium' : 'High'" />
+        <button @click="editing = true" class="text-gray-400 hover:text-gray-600 transition-colors" title="Edit trust level">
+            <!-- Alpine not happy with django template tag so inline svg here... it's a pencil -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+            </svg>
+        </button>
+    </div>
+
+    <form x-show="editing" method="post" action="{% url 'borrowd_groups:update-trust-level' group_id %}"
+              @submit="saving = true"
+              class="flex items-center gap-2">
+            {% csrf_token %}
+            <select name="trust_level"
+                    x-model="trustLevel"
+                    class="px-2 py-1 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                <option value="1">Low</option>
+                <option value="2">Medium</option>
+                <option value="3">High</option>
+            </select>
+            <button type="submit"
+                    :disabled="saving"
+                    class="px-2 py-1 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-400 text-white text-sm rounded-md transition-colors">
+                <span x-show="!saving">Save</span>
+                <span x-show="saving">...</span>
+            </button>
+            <button type="button"
+                    @click="editing = false; trustLevel = {{ trust_level }}"
+                    :disabled="saving"
+                    class="px-2 py-1 text-gray-600 hover:text-gray-800 text-sm">
+                Cancel
+            </button>
+    </form>
+</div>

--- a/templates/groups/group_detail.html
+++ b/templates/groups/group_detail.html
@@ -21,6 +21,13 @@
         </div>
         <p class="text-gray-700 mb-4">{{ object.description }}</p>
         <p class="text-gray-500">{{ object.users.count }} members</p>
+
+        {% if user_trust_level %}
+        <div class="mt-4 p-3 bg-gray-50 rounded-lg">
+            <c-groups.trust-level-editor :trust_level="user_trust_level" :group_id="object.pk" />
+        </div>
+        {% endif %}
+
         <div class="relative my-4 -mx-4 md:-mx-8">
             <hr class="border-t border-gray-200 w-full">
         </div>


### PR DESCRIPTION
+ Big ol trust level editor subcomponent because the reactive edit logic is a bit verbose

## New View
<img width="382" height="837" alt="image" src="https://github.com/user-attachments/assets/0587493e-00af-4e85-8570-4bd476499148" />

### Editing
<img width="390" height="842" alt="image" src="https://github.com/user-attachments/assets/d6120b8b-8517-44ba-8209-909bc01a0973" />
