### PR TITLE
Change navbar menu items

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -71,15 +71,9 @@
         </a>
       </li>
       <li>
-        <a href="javascript:void(0)" aria-disabled="true" class="flex items-center gap-3 py-3 opacity-60 cursor-not-allowed">
+        <a href="https://borrowd.org/faq/"  class="flex items-center gap-3 py-3">
           <i class="fas fa-circle-question text-lg"></i>
           <span>FAQ</span>
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'profile' %}" class="flex items-center gap-3 py-3">
-          <i class="fas fa-gear text-lg"></i>
-          <span>Settings</span>
         </a>
       </li>
       <li>


### PR DESCRIPTION
linked to #223.

# Summary
- Removed the settings menu item.
- Un-disabled the FAQ link. Linked it to https://borrowd.org/faq/



# Images

Before:
<img width="632" height="530" alt="Screenshot 2025-12-16 at 5 27 50 PM" src="https://github.com/user-attachments/assets/295b4d80-2a2f-4a34-94f6-b3b7421e3854" />


After:
<img width="511" height="391" alt="Screenshot 2025-12-16 at 5 26 22 PM" src="https://github.com/user-attachments/assets/d59cf191-e840-4f3b-9dce-ff021ecf921b" />
