### PR TITLE
Change notification text that is shown when user updates profile.

### DIFF
--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -25,7 +25,7 @@ def profile_view(request: HttpRequest) -> HttpResponse:
         form = ProfileUpdateForm(request.POST, request.FILES, instance=profile)
         if form.is_valid():
             form.save()
-            messages.success(request, "Your profile has been updated successfully.")
+            messages.success(request, "Profile updated")
             return redirect("profile")
     else:
         form = ProfileUpdateForm(instance=profile)


### PR DESCRIPTION
# Summary

The [Figma](https://www.figma.com/design/wMliTL8KGBlUACk0d8fkZ3/Borrow-d---Mobile-App--mid-fidelity-?node-id=746-18050&t=gJkTisIoAUYovZfk-1) profile flow shows the toast text as "Profile updated", whereas it previously showed "Your profile has been updated successfully." This PR changes the text to the updated version.

# Media

## Before
<img width="468" height="710" alt="Screenshot 2025-12-30 at 10 18 14 AM" src="https://github.com/user-attachments/assets/e32874f5-e597-4f7c-ada9-422df38e086a" />


## After

https://github.com/user-attachments/assets/7fe74b0b-978f-499f-9366-cf928db22182


# Closes
- #211
  - The only difference here is that the notification text needed to be changed. Otherwise, the flow is already as desired.
