### PR TITLE
231 ux notification alerts - match Figma

### DIFF
--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -25,7 +25,7 @@ def profile_view(request: HttpRequest) -> HttpResponse:
         form = ProfileUpdateForm(request.POST, request.FILES, instance=profile)
         if form.is_valid():
             form.save()
-            messages.success(request, "Your profile has been updated successfully.")
+            messages.success(request, "Profile updated")
             return redirect("profile")
     else:
         form = ProfileUpdateForm(instance=profile)

--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -4,6 +4,10 @@
     {% for message in messages %}
     <div class="toast toast-center z-100">
         <div class="alert alert-{{ message.tags }}">
+            <!-- TODO: use icon library not inline svg -->
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+            </svg>
             <span>{{ message }}</span>
         </div>
     </div>


### PR DESCRIPTION
Nevermind the specific screen/action, more showing screenshots for visual of toast notification.

One exception to that is I did update the `Profile updated` text to match Figma.

Closes https://github.com/borrowd/borrowd/pull/232

## Success Notif.
<img width="363" height="696" alt="image" src="https://github.com/user-attachments/assets/b6f68307-d8ec-41ba-b011-990aeca719b5" />

## Warning Notif. 
<img width="333" height="679" alt="image" src="https://github.com/user-attachments/assets/44f31679-fa43-4203-a87c-6d9300265c20" />

## Error Notif.
<img width="334" height="684" alt="image" src="https://github.com/user-attachments/assets/4d21bdcf-6a76-4273-8038-99dbd41d15ba" />

