### PR TITLE
fix/317 Update item category bug

### DIFF
--- a/borrowd_items/forms.py
+++ b/borrowd_items/forms.py
@@ -39,12 +39,6 @@ class ItemForm(forms.ModelForm[Item]):
                     "placeholder": "Enter a detailed description of your item...",
                 }
             ),
-            # The category filter modal manages the UI and sends the chosen
-            # categories back to this widget.
-            # See:
-            # `templates/items/item_form.html`
-            # `templates/components/items/category_filter_modal.html`
-            "categories": forms.SelectMultiple(attrs={"class": "hidden"}),
             "trust_level_required": forms.Select(
                 attrs={"class": "select select-bordered w-full"}
             ),

--- a/templates/items/item_form.html
+++ b/templates/items/item_form.html
@@ -24,13 +24,12 @@
                 <!--
                     Category field
 
-                    1. Keep the <select multiple> in the DOM but hide it visually
-                    2. Use Alpine.js to manage selected categories (selectedIds array)
-                    3. When user confirms modal selections, copy Alpine state to the
-                       hidden <select> by marking matching <option>s as selected
-                    4. When user clicks "Save item", browser submits the form with
+                    1. Alpine.js manages selected categories via the selectedIds array
+                    2. A reactive <template x-for> generates hidden <input> fields
+                       for each selected ID, so the form always submits the current state
+                    3. When user clicks "Save item", browser submits the form with
                        POST data like: categories=3&categories=7
-                    5. Django's ItemForm processes this (borrowd_items/forms.py)
+                    4. Django's ItemForm processes this (borrowd_items/forms.py)
 
                 -->
                 <div x-data="{
@@ -68,32 +67,12 @@
                         return truncated + ' + ' + (this.selectedIds.length - 1) + ' more';
                     },
 
-                    /*
-                     * Copy selectedIds to the hidden <select> element.
-                     *
-                     * e.g.:
-                     *   selectedIds = ['3', '7']
-                     *   <option value='1'>Tools</option>        -> selected = false
-                     *   <option value='3'>Electronics</option>  -> selected = true
-                     *   <option value='7'>Kitchen</option>      -> selected = true
-                     *
-                     * POST sends categories=3&categories=7
-                     */
-                    writeSelectedIdsToHiddenSelect() {
-                        const select = this.$refs.categoryFormSelect;
-                        for (const opt of select.options) {
-                            opt.selected = this.selectedIds.includes(opt.value);
-                        }
-                    },
-
                     clearFilters() {
                         this.selectedIds = [];
-                        this.writeSelectedIdsToHiddenSelect();
                         closeModal('item-category-modal');
                     },
 
                     applyFilters() {
-                        this.writeSelectedIdsToHiddenSelect();
                         closeModal('item-category-modal');
                     }
                 }">
@@ -105,22 +84,13 @@
                     </button>
 
                     <!--
-                        Hidden <select multiple> for multiple item categories.
-                        This is the actual form field that Django's ItemForm reads.
-                        Alpine writes to this via writeSelectedIdsToHiddenSelect().
-                        See borrowd_items/forms.py for widget configuration.
+                        Hidden inputs for selected categories.
+                        Alpine reactively generates one <input> per selected ID,
+                        so the form always submits the current selectedIds state.
                     -->
-                    <select x-ref="categoryFormSelect"
-                            name="{{ field.html_name }}"
-                            id="{{ field.id_for_label }}"
-                            multiple
-                            class="hidden">
-                        {% for choice in field.field.choices %}
-                        <option value="{{ choice.0 }}" {% if field.value and choice.0|stringformat:"s" in field.value %}selected{% endif %}>
-                            {{ choice.1 }}
-                        </option>
-                        {% endfor %}
-                    </select>
+                    <template x-for="id in selectedIds" :key="id">
+                        <input type="hidden" name="{{ field.html_name }}" :value="id">
+                    </template>
 
                     {% include "components/items/category_filter_modal.html" with modal_id="item-category-modal" confirm_button_text="Filter categories" %}
                 </div>


### PR DESCRIPTION
# Fix: Item category field clearing on edit

**Issue:** closes #317

When editing an existing item (e.g. changing its name) and clicking "Save" without touching the category field, the categories disappeared and the form showed a *"This field is required"* error, even if the user didn't touch the categories field. Additionally, the category field would become blank.

## Old Flow (happy path, modal opened + categories confirmed)

### Step 1 — Page loads, Alpine initializes `selectedIds` from Django

Django renders the template with `field.value` (the item's current category IDs). Alpine picks these up and builds its own JS array:

```django
selectedIds: [{% for val in field.value %}'{{ val }}',{% endfor %}]
// Result on an item with categories 3 and 7:
// selectedIds: ['3', '7']
```

This powered the modal UI (which badges appear toggled on) and the trigger button text. This worked fine.

### Step 2 — Page loads, Django also tries to pre-select the hidden `<select>`

Separately, a hidden `<select multiple>` element was the actual form field the browser would submit. Django template logic tried to mark the right `<option>` elements as `selected`:

```django
<select name="categories" multiple class="hidden">
    <option value="3" {% if "3" in field.value %}selected{% endif %}>Electronics</option>
    <option value="7" {% if "7" in field.value %}selected{% endif %}>Kitchen</option>
</select>
```

### Step 3 — User opens modal, picks categories, confirms

When the user clicked "Confirm" in the modal, `applyFilters()` called `writeSelectedIdsToHiddenSelect()`, which looped through the `<select>` options and set `selected` based on Alpine's `selectedIds`:

```js
writeSelectedIdsToHiddenSelect() {
    const select = this.$refs.categoryFormSelect;
    for (const opt of select.options) {
        opt.selected = this.selectedIds.includes(opt.value);
    }
}
```

### Step 4 — User submits the form

The browser submits the hidden `<select>`'s selected options as POST data. Django's `ItemForm` reads `categories=3&categories=7` and saves.

## Where it broke

The bug is in Step 2 where the Django template check sets the values of the ids in :
```django
<option
  value="{{ choice.0 }}"
  {% if field.value and choice.0|stringformat:"s" in field.value %}
  selected
  {% endif %}
>
  {{ choice.1 }}
</option>
```

`choice.0|stringformat:"s"` produces a string like `"3"`, but `field.value` is a list of integer PKs like `[3, 7]` (see `borrowd_items/apps.py/BorrowdItemsConfig:5`, and [BigAutoField](https://docs.djangoproject.com/en/5.2/ref/models/fields/#bigautofield). [Since `"3" in [3, 7]` is `False`](https://docs.python.org/3/reference/expressions.html#membership-test-operations), `selected` was never set on page load.

This meant Alpine's `selectedIds` was correct (`['3', '7']`), but the hidden `<select>` had zero options selected. Hence why the ui showed the correct categories selected, but form submission failed.

Since `writeSelectedIdsToHiddenSelect()` only ran inside `applyFilters()` and `clearFilters()` (Step 3), the `<select>` would stay broken unless the user opened the modal.

So when a user edited an item and just changed the name without touching categories:

1. Alpine's `selectedIds` = `['3', '7']` — button text shows "Electronics + 1 more" (looks fine)
2. Hidden `<select>` has no options selected (type mismatch, never synced)
3. User hits Save, browser submits `categories=` (empty)
4. Django returns a validation error: *"This field is required"*

## The fix

An easy fix would have been to add `x-effect` or `x-init` to auto-call `writeSelectedIdsToHiddenSelect` on page load or whenever `selectedIds` changed.

But, instead of maintaining two sources of state and syncing them, I opted to just reduce the amount of state.

I replaced the hidden `<select>` with a `<template x-for>` that generates hidden `<input>` fields directly from `selectedIds`. When the user selects a new category, or when a category is loaded on page initialization, Alpine creates a hidden input for that specific category.

## New Flow

### Step 1 — Page loads, Alpine initializes `selectedIds` (same as before)

```js
selectedIds: ['3', '7']
```

### Step 2 — Alpine generates hidden inputs

`x-for` creates one `<input>` per selected ID:

```html
<template x-for="id in selectedIds" :key="id">
    <input type="hidden" name="categories" :value="id">
</template>
```

On page load with `selectedIds = ['3', '7']`, the DOM contains:

```html
<input type="hidden" name="categories" value="3">
<input type="hidden" name="categories" value="7">
```

### Step 3 — User submits the form

The browser submits all hidden inputs as POST data: `categories=3&categories=7`. Django's `ItemForm` reads this and saves. This works whether the user opened the modal or not.

---

The `SelectMultiple` widget config in `forms.py` was no longer rendered by the template, so I removed it.


## Media


https://github.com/user-attachments/assets/7619b479-619b-47a6-b136-b48ed87f6b85

