### PR TITLE
fix: visual consistency and wording across pages

### DIFF
--- a/templates/account/confirm_login_code.html
+++ b/templates/account/confirm_login_code.html
@@ -32,7 +32,7 @@
     />
 
     <c-button type="submit" class="btn btn-primary w-full">
-      {% trans "Sign In" %}
+      {% trans "Sign in" %}
     </c-button>
 
     <c-button-nav

--- a/templates/components/items/action_buttons_with_status.html
+++ b/templates/components/items/action_buttons_with_status.html
@@ -73,7 +73,7 @@ For variant='card', also accepts:
         <form method="POST" action="{% url 'item-borrow' item.pk %}" class="flex-1">
             {% csrf_token %}
             <input type="hidden" name="action" value="CANCEL_REQUEST">
-            <button type="submit" class="btn btn-soft btn-primary btn-sm md:btn-md w-full">Cancel Request</button>
+            <button type="submit" class="btn btn-soft btn-primary btn-sm md:btn-md w-full">Cancel request</button>
         </form>
         {% else %}
         <form method="POST" action="{% url 'item-borrow' item.pk %}" class="flex-1">
@@ -159,7 +159,7 @@ For variant='card', also accepts:
                 <form method="POST" action="{% url 'item-borrow' item.pk %}" class="flex-1">
                     {% csrf_token %}
                     <input type="hidden" name="action" value="CANCEL_REQUEST">
-                    <button type="submit" class="btn btn-soft btn-primary w-full">Cancel Request</button>
+                    <button type="submit" class="btn btn-soft btn-primary w-full">Cancel request</button>
                 </form>
                 {% else %}
                 <form method="POST" action="{% url 'item-borrow' item.pk %}" class="flex-1">

--- a/templates/groups/group_detail.html
+++ b/templates/groups/group_detail.html
@@ -33,12 +33,12 @@
         </div>
         <div>
             <c-button-nav url="{% url 'borrowd_groups:group-invite' object.pk %}" class="btn btn-secondary">
-                Get Invite Link
+                Get invite link
             </c-button-nav>
             <!-- only moderators can edit Group -->
             {% if is_moderator %}
             <c-button-nav url="{% url 'borrowd_groups:group-edit' object.pk %}" class="btn btn-warning">
-                Edit Group
+                Edit group
             </c-button-nav>
             {% endif %}
         </div>

--- a/templates/groups/group_invite.html
+++ b/templates/groups/group_invite.html
@@ -5,11 +5,11 @@
 <c-box>
      <div class="flex flex-col">
         <c-h1>{{ object.name }}</c-h1>
-        <c-h2 class="text-gray-500 mb-4">Invite Link</c-h2>
+        <c-h2 class="text-gray-500 mb-4">Invite link</c-h2>
         <p class="text-gray-700 mb-4 break-all whitespace-normal overflow-hidden" id="join-link">
             {{ join_url}}
         </p>
-        <c-button @click.prevent="onShareClick">Copy Link</c-button>
+        <c-button @click.prevent="onShareClick">Copy link</c-button>
     </div>
 </c-box>
 <script>

--- a/templates/items/_trust_level_info_content.html
+++ b/templates/items/_trust_level_info_content.html
@@ -1,11 +1,13 @@
-<p class="mb-4">At the heart of Borrow'd is trust. Each group you join gets a trust level (High or Standard), which determines what kinds of items they can request from you. For example:</p>
+<p class="mb-4">At the heart of Borrow'd is trust.</p>
 
 <div class="mb-4">
-    <p class="font-bold mb-2"><span class="text-borrowd-plum-600">High trust:</span> Super Besmout Friends</p>
-    <p>If you mark an item as High trust, it can only be seen and borrowed by people in groups you've marked as High trust. Use this for items that are valuable, fragile, or personal — like electronics, specialized tools, or anything you'd only lend to people you know well. Your trust settings are private — no one else can see which groups you've marked as High trust.</p>
+    <p class="font-bold mb-2">Standard trust</p>
+    <p>Standard trust is the default. Items that are marked as "Standard" are visible to the people in the groups you've joined. Use this for everyday items you're comfortable sharing more widely.</p>
 </div>
 
 <div class="mb-4">
-    <p class="font-bold mb-2"><span class="text-indigo-600">Standard trust:</span> Neighborhood Community</p>
-    <p>Items marked as "Standard" trust are visible to people in the groups you've joined. Use this for everyday items you're comfortable sharing more widely.</p>
+    <p class="font-bold mb-2">High trust</p>
+    <p>High trust items can only be seen and borrowed by people in groups you've marked as High trust. Use this for items that are valuable, fragile, or personal — the things you only want to lend to the people you know well.</p>
 </div>
+
+<p class="text-sm text-gray-500">Note: Your trust settings are private — no one else can see which items or groups you've marked as High trust.</p>

--- a/templates/items/item_form.html
+++ b/templates/items/item_form.html
@@ -132,7 +132,7 @@
                 <div class="mb-2">No photos</div>
             {% endif %}
             {% if view.object.photos.count < 5 %}
-                <c-button-nav url="{% url 'itemphoto-create' item_pk=object.pk %}?next={% url 'item-edit' object.pk %}">Add Photo</c-button-nav>
+                <c-button-nav url="{% url 'itemphoto-create' item_pk=object.pk %}?next={% url 'item-edit' object.pk %}">Add photo</c-button-nav>
             {% else %}
                 <div class="text-gray-500 italic">Photo limit (5) reached. Delete a photo if you want to add another.</div>
             {% endif %}
@@ -140,7 +140,7 @@
         {% endif %}
 
         <div class="mt-4 flex justify-end">
-            <c-button type="submit" class="btn btn-primary mr-2">Add item</c-button>
+            <c-button type="submit" class="btn btn-primary mr-2">{% if form.instance.pk %}Save item{% else %}Add item{% endif %}</c-button>
             {% if form.instance.pk %}
                 <c-button-nav url="{% url 'item-detail' form.instance.pk %}" class="btn">
                     Cancel
@@ -171,5 +171,5 @@
     {% endif %}
 </div>
 
-{% include "components/modal.html" with modal_id="trust-level-info-modal" modal_title="Group trust levels" modal_size="full" modal_content_template="items/_trust_level_info_content.html" cancel_button_text="Got it" %}
+{% include "components/modal.html" with modal_id="trust-level-info-modal" modal_title="Trust levels" modal_size="full" modal_content_template="items/_trust_level_info_content.html" cancel_button_text="Got it" %}
 {% endblock %}

--- a/templates/users/inventory.html
+++ b/templates/users/inventory.html
@@ -53,7 +53,7 @@
                     <p class="text-gray-800 text-xl text-center font-semibold mb-2">You have no items</p>
                     <p class="text-gray-600 text-center mb-6">Add an item to start sharing.</p>
                     <a href="{% url 'item-create' %}" class="btn btn-primary">
-                        Add an item
+                        Add item
                     </a>
                 </div>
                 {% endif %}


### PR DESCRIPTION
Resolves #346, Resolves #353, Resolves #367, Resolves #313.

- Ensure sentence case for buttons (Get invite link, Edit group, Copy link, Cancel request, Sign in, Add photo, Add item, Save item)
- Standardize empty-state wording on inventory page to 'Add item'
- Update trust level modal title to 'Trust levels' and rewrite content to be item-focused and plain text