### PR TITLE
Updated the repositioning logic to work on safari

### DIFF
--- a/templates/components/groups/member_row.html
+++ b/templates/components/groups/member_row.html
@@ -14,35 +14,35 @@
     </div>
     <!-- member actions -->
     {% if is_moderator and member.user_id != user.id %}
-    <div class="relative" x-data="{ open: false, placement:'top', getBoundaryEl() {return this.$refs.btn?.closest('[members-list-boundary]') || document.body;},
+    <div class="relative" x-data="{ open: false, placement:'top', getBoundaryEl() {return this.$refs.btn?.closest('[members-list-boundary]') || null;},
                                     toggle() {
                                       if (this.open) { this.open = false; return;}
 
                                       this.open = true;
 
-                                      //  Compute the best placement for the menu (top or bottom)
-                                      // based on available space within the parent boundary panel/card.
-                                      // works with scrolling containers and for a dynamic menu size.
-
                                       this.$nextTick(() => {
-                                        const btn = this.$refs.btn;
-                                        const menu = this.$refs.menu;
-                                        const boundary = this.getBoundaryEl();
+                                        requestAnimationFrame(() => {
+                                          const btn = this.$refs.btn;
+                                          const menu = this.$refs.menu;
+                                          const boundary = this.getBoundaryEl();
 
-                                        if (!btn || !menu || !boundary) return;
+                                          if (!btn || !menu) return;
 
-                                        const btnRect = btn.getBoundingClientRect();
-                                        const menuRect = menu.getBoundingClientRect();
-                                        const boundaryRect = boundary.getBoundingClientRect();
+                                          const btnRect = btn.getBoundingClientRect();
+                                          const menuRect = menu.getBoundingClientRect();
 
-                                        // Space within the boundary
-                                        const spaceBelow = boundaryRect.bottom - btnRect.bottom;
-                                        const spaceAbove = btnRect.top - boundaryRect.top;
+                                          const boundaryRect = boundary
+                                            ? boundary.getBoundingClientRect()
+                                            : { top: 0, bottom: window.innerHeight };
 
-                                        this.placement =
-                                          (spaceBelow < menuRect.height && spaceAbove > spaceBelow)
-                                            ? 'top'
-                                            : 'bottom';
+                                          const spaceBelow = boundaryRect.bottom - btnRect.bottom;
+                                          const spaceAbove = btnRect.top - boundaryRect.top;
+
+                                          this.placement =
+                                            (spaceBelow < menuRect.height && spaceAbove > spaceBelow)
+                                              ? 'top'
+                                              : 'bottom';
+                                        });
                                       });
                                     }
                                   }"


### PR DESCRIPTION
Changes made:
delay menu measurement with requestAnimationFrame after $nextTick
replace document.body as the fallback boundary with viewport-based bounds
keep the existing Alpine structure and toggle behavior unchanged
Why:
Safari was not always returning stable layout measurements at the moment the menu placement was computed, and using document.body as the fallback boundary could produce inconsistent results. This change makes the placement logic more reliable while keeping the implementation minimal.