### PR TITLE
Fix #386: Hide trust level from non-owners

### DIFF
--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -199,6 +199,7 @@ class ItemDetailView(
 
         action_context = self.object.get_action_context_for(user=user)
         context["action_context"] = action_context
+        context["is_owner"] = self.object.owner == user
 
         request_txn = (
             Transaction.objects.filter(item=self.object).order_by("-created_at").first()

--- a/templates/items/item_detail.html
+++ b/templates/items/item_detail.html
@@ -163,6 +163,8 @@
             </div>
           </div>
 
+          <!-- Only show trust level to the owner -->
+          {% if is_owner %}
           <div class="px-3 flex items-center gap-3 mb-4 lg:px-0 lg:mt-2">
             <div
               class="text-sm font-normal underline underline-offset-2 decoration-dotted bg-base-content/60 bg-clip-text text-transparent"
@@ -188,6 +190,7 @@
               {% include "icons/information-circle.svg" %}
             </span>
           </div>
+          {% endif %}
 
           <div
             class="px-3 text-[12px] mt-4 lg:px-0 lg:text-[15px] lg:leading-7"


### PR DESCRIPTION
# Summary
- Hides trust level on the item detail page from anyone who is not the item owner.

## Issues
Closes #386 

## Media
<img width="1319" height="781" alt="Screenshot 2026-03-26 at 8 01 37 PM" src="https://github.com/user-attachments/assets/d532f800-5ce3-4673-b317-7b77cdacf4e6" />
