### PR TITLE
fix: open FAQ and external footer links in new tab (#365)

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -6,14 +6,14 @@
         <img class="w-36" src="{% static 'borrowd-logo.svg' %}"
             alt="Borrow'd's logo, complete with friendly bumble bee" />
         <!-- Privacy Policy -->
-        <a href="https://borrowd.org/privacy-policy/" class="hover:text-borrowd-indigo-600">
+        <a href="https://borrowd.org/privacy-policy/" target="_blank" rel="noopener noreferrer" class="hover:text-borrowd-indigo-600">
             <p>Privacy Policy</p>
         </a>
         <!-- Terms of Use -->
-        <a href="https://borrowd.org/terms-of-use/" class="hover:text-borrowd-indigo-600">
+        <a href="https://borrowd.org/terms-of-use/" target="_blank" rel="noopener noreferrer" class="hover:text-borrowd-indigo-600">
             <p>Terms of Use</p>
         </a>
-        <a href="https://github.com/borrowd" class="flex space-x-2 hover:text-borrowd-indigo-600">
+        <a href="https://github.com/borrowd" target="_blank" rel="noopener noreferrer" class="flex space-x-2 hover:text-borrowd-indigo-600">
             {% include "icons/github_logo.html" %}
             <span>GitHub</span>
         </a>

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -69,7 +69,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="https://borrowd.org/faq/" class="flex items-center gap-3 py-3">
+                    <a href="https://borrowd.org/faq/" target="_blank" rel="noopener noreferrer" class="flex items-center gap-3 py-3">
                         <i class="fas fa-circle-question text-lg"></i>
                         <span>FAQ</span>
                     </a>


### PR DESCRIPTION
Upon clicking FAQ on the header and Privacy Policy, Terms of Use or Github on the footer, users will be redirected to the respective webpages in a new tab. Will close #365 