### PR TITLE
fix return action visibility

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -352,11 +352,8 @@ class Item(Model):
                 # Otherwise, nothing to do but wait...
                 return tuple()
         elif current_tx.status == TransactionStatus.COLLECTED:
-            # Immediately allow the other party to confirm return.
-            if current_tx.updated_by != user:
-                return (ItemAction.MARK_RETURNED,)
-            else:
-                return tuple()
+            # Either borrower or lender can assert return.
+            return (ItemAction.MARK_RETURNED,)
 
         elif current_tx.status == TransactionStatus.RETURN_ASSERTED:
             # Make sure the same person doesn't confirm the assertion


### PR DESCRIPTION
# Summary

There was an issue where, after an item was retrieved (i.e., currently borrowed), the user who had marked the item as having been picked up could **not** mark the item as having been returned. This is not the [intended flow](https://www.figma.com/design/wMliTL8KGBlUACk0d8fkZ3/Borrow-d---Mobile-App--mid-fidelity-?node-id=746-37509&m=dev). This fix allows both users to mark the item as having been returned now.

## Media

### Before
Borrower marked the item as having been collected. They cannot see the return item action.
<img width="1424" height="557" alt="Screenshot 2026-03-30 at 10 50 01 AM" src="https://github.com/user-attachments/assets/f3bbde13-9636-470c-b0c3-38f9ebb86ba3" />

### After
Return item action visible to both parties.
<img width="1438" height="782" alt="Screenshot 2026-03-30 at 10 54 57 AM" src="https://github.com/user-attachments/assets/3b1cc412-7170-44ad-aa48-773c9ad55654" />
