### PR TITLE
login code generator function overide

### DIFF
--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -138,6 +138,8 @@ AUTH_USER_MODEL = "borrowd_users.BorrowdUser"
 
 LOGIN_REDIRECT_URL = reverse_lazy("item-list")
 
+ACCOUNT_ADAPTER = "borrowd_users.adapters.BorrowdAccountAdapter"
+ACCOUNT_LOGIN_BY_CODE_FORMAT = {"numeric": True, "dashed": False, "length": 6}
 ACCOUNT_LOGIN_BY_CODE_ENABLED = True
 ACCOUNT_LOGIN_METHODS = ["email"]
 

--- a/borrowd_users/adapters.py
+++ b/borrowd_users/adapters.py
@@ -1,0 +1,12 @@
+import string
+
+from allauth.account.adapter import DefaultAccountAdapter
+from django.utils.crypto import get_random_string
+
+
+class BorrowdAccountAdapter(DefaultAccountAdapter):  # type: ignore[misc]
+    """Project-owned allauth adapter for auth flow customizations."""
+
+    def generate_login_code(self) -> str:
+        """Generate numeric-only login codes for email sign-in."""
+        return get_random_string(length=6, allowed_chars=string.digits)


### PR DESCRIPTION
## Summary

This PR implements digit-only login codes for email authentication by overriding the default login code generator in allauth.

## Changes

- **borrowd/config/base.py**: Added `ACCOUNT_ADAPTER` to use the custom adapter and configured `ACCOUNT_LOGIN_BY_CODE_FORMAT` for 6-digit numeric codes.
- **borrowd_users/adapters.py** (new file): Created `BorrowdAccountAdapter` class with `generate_login_code()` method that generates a 6-character string using only digits.

## Motivation

Addresses issue #351 by ensuring login codes are numeric-only for better usability and security.

## Testing

- Verified the adapter generates 6-digit codes.
- Confirmed allauth uses the custom adapter via the config settings.