### PR TITLE
style(templates): center align photos in item form layout

### DIFF
--- a/templates/items/item_form.html
+++ b/templates/items/item_form.html
@@ -158,7 +158,7 @@
                     <div class="border border-base-100 rounded-lg px-[10px] py-4 flex flex-col gap-4 items-center">
 
                         {# Grid: existing saved photos + pending previews #}
-                        <div class="flex flex-wrap gap-6 w-fit"
+                        <div class="flex flex-wrap gap-6 justify-center"
                              x-show="{{ view.object.photos.count }} > 0 || pendingPreviews.length > 0">
                             {% for photo in view.object.photos.all %}
                                 <div class="border border-base-100 rounded flex flex-col items-center pb-2 overflow-hidden w-full max-w-[96px]">


### PR DESCRIPTION
## Center align photos in item form layout.

### Mobile View:
<img width="359" height="643" alt="Mobile_view" src="https://github.com/user-attachments/assets/a9f4db66-7d18-46e2-8e2a-f26b2c9f8311" />

### Desktop View:
<img width="1161" height="957" alt="desktop view" src="https://github.com/user-attachments/assets/c11a5664-1917-4b2e-b9bf-560f68300fdb" />

