### PR TITLE
fix error text color

### DIFF
--- a/templates/components/form/field.html
+++ b/templates/components/form/field.html
@@ -78,8 +78,6 @@
         </p>
     {% endif %}
     {% if errors %}
-        <p class="label text-error text-xs">
-            {{ errors }}
-        </p>
+            <p class="mt-1 text-error text-xs">{{ errors|striptags }}</p>
     {% endif %}
 </fieldset>

--- a/templates/components/form/textarea.html
+++ b/templates/components/form/textarea.html
@@ -33,9 +33,7 @@
             {{ help_text }}
         </p>
     {% endif %}
-    {% if errors %}
-        <p class="label text-error text-xs">
-            {{ errors }}
-        </p>
-    {% endif %}
+        {% if errors %}
+            <p class="mt-1 text-error text-xs">{{ errors|striptags }}</p>
+        {% endif %}
 </fieldset>


### PR DESCRIPTION
Closes #417 

The error field should be red now.
<img width="780" height="897" alt="image" src="https://github.com/user-attachments/assets/38cfb605-ebb4-4353-a43c-b4ab2161daf6" />
