### PR TITLE
Fix text in trust level field

### DIFF
--- a/templates/items/item_detail.html
+++ b/templates/items/item_detail.html
@@ -129,17 +129,13 @@
 
                             {% if "High" in item.get_trust_level_required_display %}
                                 <div class="badge badge-success badge-soft font-medium text-xs border-xl p-3">
-                                    {% include "icons/arrow-up.svg" %}
-
                                     {{
-                                    item.get_trust_level_required_display }} Trust
+                                    item.get_trust_level_required_display }}
                                 </div>
                             {% elif "Standard" in item.get_trust_level_required_display %}
                                 <div class="badge badge-soft text-xs border-xl p-3">
-                                    {% include "icons/medium-icon.svg" %}
-
                                     {{
-                                    item.get_trust_level_required_display }} Trust
+                                    item.get_trust_level_required_display }}
                                 </div>
                             {% endif %}
 


### PR DESCRIPTION
Removed Icon and "Trust" from the text
<img width="337" height="681" alt="image" src="https://github.com/user-attachments/assets/a8bd6d0c-508b-4708-a518-ddbda8918a9a" />
