### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.env
+node_modules/
+.venv/
+build/
+media/
+db.sqlite3
+staticfiles/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+docs/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build frontend assets
+FROM node:22-slim AS frontend
+WORKDIR /app
+COPY package*.json vite.config.mjs ./
+RUN npm ci
+COPY static/ ./static/
+COPY templates/ ./templates/
+RUN npm run build
+
+# Stage 2: Python application
+FROM python:3.13-slim
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+COPY --from=frontend /app/build ./build
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "borrowd.wsgi:application"]

--- a/borrowd/config/docker/django.py
+++ b/borrowd/config/docker/django.py
@@ -1,0 +1,32 @@
+from borrowd.config.dev.django import *  # noqa: F401, F403
+
+from borrowd.config.env import env
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": env("POSTGRES_DB", default="borrowd"),
+        "USER": env("POSTGRES_USER", default="borrowd"),
+        "PASSWORD": env("POSTGRES_PASSWORD", default="borrowd"),
+        "HOST": env("POSTGRES_HOST", default="db"),
+        "PORT": env("POSTGRES_PORT", default="5432"),
+    }
+}
+
+ALLOWED_HOSTS = ["*"]
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=["https://*.veilstreamapp.com"])
+
+STATIC_ROOT = os.path.join(env("PLATFORM_APP_DIR", default="/app"), "staticfiles")
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": False,
+        "manifest_path": BASE_DIR / "build" / "manifest.json",  # noqa: F405
+    }
+}
+
+if env.bool("LOCAL_SENTRY_ENABLED", default=False):
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,  # noqa: F405
+        send_default_pii=True,
+        environment="local",
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  db:
+    image: postgres:17
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: borrowd
+      POSTGRES_USER: borrowd
+      POSTGRES_PASSWORD: borrowd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U borrowd"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: >
+      sh -c "python manage.py migrate &&
+             python manage.py loaddata items/item_categories &&
+             python manage.py runserver 0.0.0.0:8000"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+      - /app/.venv
+      - /app/build
+      - media:/app/media
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DJANGO_SETTINGS_MODULE: borrowd.config.docker.django
+      DJANGO_SECRET_KEY: insecure-docker-dev-secret-key
+      POSTGRES_HOST: db
+      POSTGRES_DB: borrowd
+      POSTGRES_USER: borrowd
+      POSTGRES_PASSWORD: borrowd
+      DEBUG: true
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  media:


### PR DESCRIPTION
Ike asked if borrowd PRs could work in VeilStream (I'm the dev of this tool).
For it to work, it needs to have a docker compose file in the borrowd repo.

With that, we can spin up preview environments based off any branch. here's a working copy of your stack running in a veilstream environment (TTL set for 7 days, by default it's shorter)
https://void-lion.env.veilstreamapp.com/


