### PR TITLE
Fix image upload orientation handling

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -27,6 +27,7 @@ from borrowd_permissions.models import ItemOLP
 from borrowd_users.models import BorrowdUser
 
 from .exceptions import InvalidItemAction, ItemAlreadyRequested
+from .processors import AutoOrientProcessor
 
 
 class ItemAction(TextChoices):
@@ -630,7 +631,7 @@ class ItemPhoto(Model):
     item_id: int  # hint for mypy
     image = ProcessedImageField(
         upload_to="items/",
-        processors=[ResizeToFit(1600, 1600)],
+        processors=[AutoOrientProcessor(), ResizeToFit(1600, 1600)],
         format="JPEG",
         options={"quality": 75},
     )

--- a/borrowd_items/processors.py
+++ b/borrowd_items/processors.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageOps  # type: ignore[import-not-found]
+from PIL import Image, ImageOps
 
 
 class AutoOrientProcessor:

--- a/borrowd_items/processors.py
+++ b/borrowd_items/processors.py
@@ -1,0 +1,8 @@
+from PIL import Image, ImageOps  # type: ignore[import-not-found]
+
+
+class AutoOrientProcessor:
+    """Normalize image orientation based on EXIF metadata when present."""
+
+    def process(self, image: Image.Image) -> Image.Image:
+        return ImageOps.exif_transpose(image)

--- a/borrowd_items/tests/test_photo_orientation.py
+++ b/borrowd_items/tests/test_photo_orientation.py
@@ -1,0 +1,67 @@
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from PIL import Image  # type: ignore[import-not-found]
+
+from borrowd.models import TrustLevel
+from borrowd_items.models import Item, ItemPhoto
+from borrowd_users.models import BorrowdUser
+
+
+def build_uploaded_image(
+    *,
+    width: int,
+    height: int,
+    exif_orientation: int | None = None,
+) -> SimpleUploadedFile:
+    image = Image.new("RGB", (width, height), color="red")
+    image_bytes = BytesIO()
+
+    if exif_orientation is None:
+        image.save(image_bytes, format="JPEG")
+    else:
+        exif = Image.Exif()
+        exif[274] = exif_orientation
+        image.save(image_bytes, format="JPEG", exif=exif)
+
+    image_bytes.seek(0)
+    return SimpleUploadedFile(
+        name="photo.jpg",
+        content=image_bytes.read(),
+        content_type="image/jpeg",
+    )
+
+
+class ItemPhotoOrientationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = BorrowdUser.objects.create(
+            username="orientation-owner",
+            email="orientation-owner@example.com",
+        )
+        cls.item = Item.objects.create(
+            name="Orientation Test Item",
+            description="Used for photo orientation tests",
+            owner=cls.owner,
+            trust_level_required=TrustLevel.STANDARD,
+        )
+
+    def test_phone_exif_orientation_is_applied_to_processed_image(self) -> None:
+        uploaded_image = build_uploaded_image(width=300, height=500, exif_orientation=6)
+
+        item_photo = ItemPhoto.objects.create(item=self.item, image=uploaded_image)
+
+        with Image.open(item_photo.image) as processed_image:
+            self.assertEqual(processed_image.size, (1600, 960))
+
+        self.assertEqual(item_photo.thumbnail.width, 200)
+        self.assertEqual(item_photo.thumbnail.height, 200)
+
+    def test_upload_without_orientation_metadata_keeps_pixel_orientation(self) -> None:
+        uploaded_image = build_uploaded_image(width=300, height=500)
+
+        item_photo = ItemPhoto.objects.create(item=self.item, image=uploaded_image)
+
+        with Image.open(item_photo.image) as processed_image:
+            self.assertEqual(processed_image.size, (960, 1600))

--- a/borrowd_items/tests/test_photo_orientation.py
+++ b/borrowd_items/tests/test_photo_orientation.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
-from PIL import Image  # type: ignore[import-not-found]
+from PIL import Image
 
 from borrowd.models import TrustLevel
 from borrowd_items.models import Item, ItemPhoto


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->

Fixes incorrect rotation on some phone-uploaded item photos. Normalized EXIF orientation before image processing. This
ensures newly uploaded images renders properly.

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #389 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- Added an EXIF auto-orientation processor so uploaded items are rotated to their intended orientation before resizing (`processors.py`)
- Updated item photo processing to run auto-orient before the 1600 image resize pipeline (`models.py`)
- Added regression tests for EXIF-oriented phone uploads and non-EXIF uploads

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Run the automated tests (run from repo root: `.\.venv\Scripts\python manage.py test borrowd_items.tests.test_photo_orientation`)
2. For a more broader check for item-photo behavior, run `.\.venv\Scripts\python manage.py test borrowd_items.tests_photo_size_validation`

## Screenshots (if UI change)
<!-- Before / After if applicable -->
Non-Applicable

## Checklist
- [x] I have tested this locally (see notes for reviewer)
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
- This fix applies to new uploads
- No schema/model migration required. Only made changes to the processing logic
- **I have not been able to test on a physical phone in a dev environment; validation was done via automated tests.** 