### PR TITLE
feat(templates): enhance group form with dynamic banner upload feature

### DIFF
--- a/templates/groups/group_form.html
+++ b/templates/groups/group_form.html
@@ -76,22 +76,99 @@ block groups_content %}
                         </p>
                     {% endif %}
 
-                    <div class="relative border-2 border-gray-200 w-full mt-1.5 rounded-md">
-                        {{ field }}
-                        {% if field.field.widget.input_type == "select" %}
-                            <svg class="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 fill="none"
-                                 viewBox="0 0 24 24"
-                                 stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                            </svg>
-                        {% endif %}
-                    </div>
-
                     {% if field.name == "banner" %}
-                        <div class="font-sans font-normal leading-[1.8] text-black/60 text-sm mt-2">
-                            Max size 5MB
+                        <div class="border border-base-100 rounded-lg px-[10px] py-4 flex flex-col gap-4 items-center mt-1.5" x-data="{ pendingPreview: null, pendingFile: null, showExisting:
+                            {% if view.object.pk and view.object.banner %}
+                                true
+                            {% else %}
+                                false
+                            {% endif %}
+                            , handleFileSelect(event) { const file = event.target.files[0]; if (!file) return; if (this.pendingPreview) URL.revokeObjectURL(this.pendingPreview); this.pendingFile = file; this.pendingPreview = URL.createObjectURL(file); event.target.value = ''; this.syncSubmitInput(); }, removePending() { URL.revokeObjectURL(this.pendingPreview); this.pendingPreview = null; this.pendingFile = null; this.syncSubmitInput(); }, removeExisting() { this.showExisting = false; document.getElementById('banner-clear-checkbox').checked = true; }, syncSubmitInput() { const dt = new DataTransfer(); if (this.pendingFile) dt.items.add(this.pendingFile); document.getElementById('banner-submit-input').files = dt.files; } }">
+
+                            {# Preview grid: existing saved banner + pending preview #}
+                            <div class="flex flex-wrap gap-6 justify-center w-full"
+                                 x-show="showExisting || pendingPreview">
+
+                                {# Existing saved banner #}
+                                {% if view.object.pk and view.object.banner %}
+                                    <div class="border border-base-100 rounded flex flex-col items-center pb-2 overflow-hidden w-full max-w-[96px]"
+                                         x-show="showExisting">
+                                        <div class="w-full aspect-square overflow-hidden rounded-t">
+                                            <img src="{{ view.object.banner.url }}"
+                                                 alt="Current picture"
+                                                 class="w-full h-full object-cover" />
+                                        </div>
+                                        <button type="button"
+                                                class="btn btn-xs gap-1 mt-2 text-[11px] font-semibold"
+                                                @click="removeExisting()">
+                                            {% include "icons/trash.svg" %}
+
+                                            Remove
+                                        </button>
+                                    </div>
+                                {% endif %}
+
+                                {# Pending preview — shown immediately, saved on form submit #}
+                                <template x-if="pendingPreview">
+                                    <div class="border border-dashed border-base-content/30 rounded flex flex-col items-center pb-2 overflow-hidden w-full max-w-[96px] relative">
+                                        <div class="w-full aspect-square overflow-hidden rounded-t">
+                                            <img :src="pendingPreview"
+                                                 alt="Pending upload"
+                                                 class="w-full h-full object-cover" />
+                                        </div>
+                                        <span class="absolute top-1 right-1 bg-base-content/70 text-base-100 text-[9px] font-semibold px-1 py-px rounded leading-none">New</span>
+                                        <button type="button"
+                                                class="btn btn-xs gap-1 mt-2 text-[11px] font-semibold"
+                                                @click="removePending()">
+                                            {% include "icons/trash.svg" %}
+
+                                            Remove
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+
+                            {# File picker — hidden once a pending file is selected (only one banner allowed) #}
+                            <fieldset class="fieldset w-full gap-0 px-[10px]" x-show="!pendingPreview">
+                                <legend class="fieldset-legend text-xs font-semibold text-base-content/60">
+                                    Upload Picture
+                                </legend>
+                                <label class="border border-base-content/20 rounded flex items-center w-full cursor-pointer bg-primary-content hover:bg-base-200/40 transition-colors h-10 overflow-hidden">
+                                    <span class="inline-flex items-center justify-center self-stretch bg-base-200 font-semibold text-sm px-4 shrink-0">Choose file</span>
+                                    <span class="text-base-content/50 text-sm truncate px-4">No file chosen</span>
+                                    {# Picker input — no name, so it is never submitted. Cleared after each selection. #}
+                                    <input type="file"
+                                           accept="image/*"
+                                           class="hidden"
+                                           @change="handleFileSelect($event)">
+                                </label>
+                                <div class="label pt-1">
+                                    <span class="label-text-alt text-base-content/60">Max size 5MB</span>
+                                </div>
+                            </fieldset>
+
+                            {# Submission input — kept in sync by DataTransfer in syncSubmitInput() #}
+                            <input type="file"
+                                   id="banner-submit-input"
+                                   name="{{ field.html_name }}"
+                                   class="hidden">
+                            <input type="checkbox"
+                                   name="{{ field.html_name }}-clear"
+                                   id="banner-clear-checkbox"
+                                   class="hidden">
+                        </div>
+                    {% else %}
+                        <div class="relative border-2 border-gray-200 w-full mt-1.5 rounded-md">
+                            {{ field }}
+                            {% if field.field.widget.input_type == "select" %}
+                                <svg class="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none"
+                                     xmlns="http://www.w3.org/2000/svg"
+                                     fill="none"
+                                     viewBox="0 0 24 24"
+                                     stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                                </svg>
+                            {% endif %}
                         </div>
                     {% endif %}
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->
Added a custom UI for the `banner` field that allows users to see a preview of the current and newly selected banner image, with options to remove either before submitting.

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #445

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- [group_form.html]Replaced the bare file input for the banner field with a custom Alpine.js upload widget that shows a live thumbnail preview of the pending upload and the currently saved banner, with per-image Remove buttons. 
- Non-banner fields retain the existing border-gray-200 wrapper. A hidden banner-submit-input is synced via DataTransfer and a hidden clear checkbox is toggled on existing-banner removal.

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1.Navigate to the edit page of a group that already has a banner - the existing banner should appear as a thumbnail with a "Remove" button.
2.Select a new image file a "New"-labelled preview thumbnail should appear and the file picker should hide.
3. Click "Remove" on the pending file. - the file picker should reappear and the pending preview should disappear.
4. Submit the form with a new banner selected. Verify the new banner is saved correctly.
5. Click "Remove" on the existing banner and submit - verify the banner is cleared.
6. Open the create-group form (no existing banner). Only the styled file picker should appear, with no thumbnail grid.
7. Submit the create form without choosing a banner - verify the form submits without errors.

## Screenshots
<!-- Before / After if applicable -->
<img width="957" height="902" alt="EDit Group" src="https://github.com/user-attachments/assets/656f7bd5-740b-466c-b7cf-6c379354e288" />


## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)


