### PR TITLE
add django-ipware to support stricter allauth logic

### DIFF
--- a/borrowd/adapters.py
+++ b/borrowd/adapters.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from allauth.account.adapter import DefaultAccountAdapter, HttpRequest
+from ipware import get_client_ip
+
+
+class IPWareAccountAdapter(DefaultAccountAdapter):  # type: ignore[misc]
+    def get_client_ip(self, request: HttpRequest) -> Any:
+        # ipware will automatically check common headers like X-Forwarded-For
+        client_ip, is_routable = get_client_ip(request)
+
+        # If ipware can't find it, we return None (which allauth expects)
+        # or you can return a fallback/dummy if you're in a local environment.
+        return client_ip

--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -176,6 +176,18 @@ AUTHENTICATION_BACKENDS = [
     "guardian.backends.ObjectPermissionBackend",
 ]
 
+# IP address handling
+
+ACCOUNT_ADAPTER = "borrowd.adapters.IPWareAccountAdapter"
+
+# Tell ipware to check Upsun's specific header first
+# Note: Django converts 'X-Client-IP' to 'HTTP_X_CLIENT_IP' in request.META
+IPWARE_META_PRECEDENCE_ORDER = (
+    "HTTP_X_CLIENT_IP",
+    "HTTP_X_FORWARDED_FOR",
+    "REMOTE_ADDR",
+)
+
 # Email
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,3 +18,6 @@ ignore_missing_imports = true
 
 [mypy-imagekit.*]
 ignore_missing_imports = True
+
+[mypy-ipware.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "django-notifications-hq @ git+https://github.com/django-notifications/django-notifications.git",
     "django-imagekit>=6.0.0",
     "sentry-sdk[django]>=2.48.0",
+    "django-ipware>=7.0.1",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,10 @@ django-imagekit==6.1.0 \
     --hash=sha256:60fa411eaf5d2d137e1d18d17b3004a6d17b482ca46b3e4b5121a5338a8fc9ff \
     --hash=sha256:b735620d101821ae0789480b3945addfeb900f0d7653c7f377e0dc1ed63d7c39
     # via borrowd
+django-ipware==7.0.1 \
+    --hash=sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47 \
+    --hash=sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709
+    # via borrowd
 django-model-utils==5.0.0 \
     --hash=sha256:041cdd6230d2fbf6cd943e1969318bce762272077f4ecd333ab2263924b4e5eb \
     --hash=sha256:fec78e6c323d565a221f7c4edc703f4567d7bb1caeafe1acd16a80c5ff82056b
@@ -199,6 +203,10 @@ python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via botocore
+python-ipware==3.0.0 \
+    --hash=sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062 \
+    --hash=sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60
+    # via django-ipware
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3 \

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ dependencies = [
     { name = "django-filter" },
     { name = "django-guardian" },
     { name = "django-imagekit" },
+    { name = "django-ipware" },
     { name = "django-notifications-hq" },
     { name = "django-storages", extra = ["s3"] },
     { name = "django-vite" },
@@ -50,6 +51,7 @@ requires-dist = [
     { name = "django-filter", specifier = ">=25.1" },
     { name = "django-guardian", specifier = ">=3.0.0" },
     { name = "django-imagekit", specifier = ">=6.0.0" },
+    { name = "django-ipware", specifier = ">=7.0.1" },
     { name = "django-notifications-hq", git = "https://github.com/django-notifications/django-notifications.git" },
     { name = "django-storages", extras = ["s3"], specifier = ">=1.14.6" },
     { name = "django-vite", specifier = ">=3.1.0" },
@@ -216,6 +218,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/5f/229c58eefe2a9051bc17152179c46002b519371001ad15097a50226e1306/django_imagekit-6.1.0.tar.gz", hash = "sha256:60fa411eaf5d2d137e1d18d17b3004a6d17b482ca46b3e4b5121a5338a8fc9ff", size = 65550, upload-time = "2026-02-22T18:17:03.951Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4f/9a3b70941982efb80fc59880a471cf26818879a00f930d80d82342cf63c1/django_imagekit-6.1.0-py3-none-any.whl", hash = "sha256:b735620d101821ae0789480b3945addfeb900f0d7653c7f377e0dc1ed63d7c39", size = 41061, upload-time = "2026-02-22T18:17:02.622Z" },
+]
+
+[[package]]
+name = "django-ipware"
+version = "7.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-ipware" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/64/c7e4791edf01ba483cce444770b3e6a930ba12195ba1eeb37b5bf6dce8a8/django-ipware-7.0.1.tar.gz", hash = "sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47", size = 6827, upload-time = "2024-04-19T20:02:49.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/33/bf539925b102d68200da5b1d3eacb8aa5d5d9a065972e8b8724d0d53bb0d/django_ipware-7.0.1-py2.py3-none-any.whl", hash = "sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709", size = 6425, upload-time = "2024-04-19T20:02:47.469Z" },
 ]
 
 [[package]]
@@ -439,6 +453,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-ipware"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/bd/ccd7416fdb30f104ddf6cfd8ee9f699441c7d9880a26f9b3089438adee05/python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60", size = 10761, upload-time = "2024-04-19T20:00:57.171Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When updating django-allauth from 65.8.0 to 65.16.1, it was no longer able to resolve ip addresses when running in Upsun. Introducing django-ipware resolves the issue. This has already been tested in staging.