### PR TITLE
Fix/343/delete available items

### DIFF
--- a/borrowd_items/filters.py
+++ b/borrowd_items/filters.py
@@ -65,12 +65,16 @@ class ItemFilter(FilterSet):  # type: ignore[misc]
         closer to a "public API".
         """
         if not hasattr(self, "_qs"):
-            qs: QuerySet[Item] = get_objects_for_user(
-                self.request.user,
-                ItemOLP.VIEW,
-                klass=Item,
-                with_superuser=False,
-            ).exclude(owner=self.request.user)
+            qs: QuerySet[Item] = (
+                get_objects_for_user(
+                    self.request.user,
+                    ItemOLP.VIEW,
+                    klass=Item,
+                    with_superuser=False,
+                )
+                .filter(deleted_at__isnull=True)
+                .exclude(owner=self.request.user)
+            )
             if self.is_bound:
                 # ensure form validation before filtering
                 self.errors

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Never, Optional
 
 from django.core.exceptions import ValidationError
@@ -152,7 +153,7 @@ class Item(Model):
         auto_now=True,
         help_text="The date and time at which the item was last updated.",
     )
-    deleted_at: DateTimeField[Never, Never] = DateTimeField(
+    deleted_at: DateTimeField[datetime | None, datetime | None] = DateTimeField(
         null=True,
         blank=True,
         default=None,
@@ -180,6 +181,11 @@ class Item(Model):
         # M2M validation only works for saved instances
         if self.pk and not self.categories.exists():
             raise ValidationError({"categories": "At least one category is required."})
+
+    def soft_delete(self, deleted_by: BorrowdUser) -> None:
+        self.deleted_at = datetime.now()
+        self.deleted_by = deleted_by
+        self.save()
 
     def get_action_context_for(self, user: BorrowdUser) -> ItemActionContext:
         """

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Never, Optional
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import models, transaction
 from django.db.models import (
     CASCADE,
     DO_NOTHING,
@@ -30,6 +30,19 @@ from borrowd_permissions.models import ItemOLP
 from borrowd_users.models import BorrowdUser
 
 from .exceptions import InvalidItemAction, ItemAlreadyRequested
+
+
+class ActiveItemQuerySet(QuerySet["Item"]):
+    def active(self):  # type: ignore[no-untyped-def]
+        return self.filter(deleted_at__isnull=True)
+
+    def deleted(self):  # type: ignore[no-untyped-def]
+        return self.filter(deleted_at__isnull=False)
+
+
+class ActiveItemManager(models.Manager["Item"]):
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        return super().get_queryset().filter(deleted_at__isnull=True)
 
 
 class ItemAction(TextChoices):
@@ -168,6 +181,8 @@ class Item(Model):
         related_name="+",
         help_text="Who performed the soft-delete. NULL means active or unknown.",
     )
+    objects = ActiveItemManager()
+    all_objects: models.Manager["Item"] = models.Manager()
 
     def __str__(self) -> str:
         return self.name

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -40,9 +40,9 @@ class ActiveItemQuerySet(QuerySet["Item"]):
         return self.filter(deleted_at__isnull=False)
 
 
-class ActiveItemManager(models.Manager["Item"]):
+class ActiveItemManager(models.Manager.from_queryset(ActiveItemQuerySet)):  # type: ignore[misc]
     def get_queryset(self):  # type: ignore[no-untyped-def]
-        return super().get_queryset().filter(deleted_at__isnull=True)
+        return super().get_queryset().active()
 
 
 class ItemAction(TextChoices):

--- a/borrowd_items/tests/test_item_deletion.py
+++ b/borrowd_items/tests/test_item_deletion.py
@@ -1,0 +1,81 @@
+from django.http import Http404
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from borrowd.models import TrustLevel
+from borrowd_items.models import Item, ItemStatus, Transaction, TransactionStatus
+from borrowd_items.views import ItemDetailView
+from borrowd_users.models import BorrowdUser
+
+
+class ItemDeletionTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = BorrowdUser.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="password",
+        )
+        self.borrower = BorrowdUser.objects.create_user(
+            username="borrower",
+            email="borrower@example.com",
+            password="password",
+        )
+        self.factory = RequestFactory()
+
+    def create_item(self, status: ItemStatus = ItemStatus.AVAILABLE) -> Item:
+        return Item.objects.create(
+            name="Test Item",
+            description="Test description",
+            owner=self.owner,
+            status=status,
+            created_by=self.owner,
+            updated_by=self.owner,
+            trust_level_required=TrustLevel.STANDARD,
+        )
+
+    def test_owner_can_delete_available_item_with_transaction_history(self) -> None:
+        item = self.create_item()
+        transaction = Transaction.objects.create(
+            item=item,
+            party1=self.owner,
+            party2=self.borrower,
+            status=TransactionStatus.CANCELLED,
+            created_by=self.borrower,
+            updated_by=self.borrower,
+        )
+
+        self.client.force_login(self.owner)
+        response = self.client.post(reverse("item-delete", args=[item.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("item-list"))
+        item.refresh_from_db()
+        transaction.refresh_from_db()
+        self.assertIsNotNone(item.deleted_at)
+        self.assertEqual(item.deleted_by, self.owner)
+        self.assertEqual(transaction.item, item)
+
+    def test_deleted_item_is_not_viewable(self) -> None:
+        item = self.create_item()
+
+        self.client.force_login(self.owner)
+        self.client.post(reverse("item-delete", args=[item.pk]))
+        request = self.factory.get(reverse("item-detail", args=[item.pk]))
+        request.user = self.owner
+
+        with self.assertRaises(Http404):
+            ItemDetailView.as_view()(request, pk=item.pk)
+
+    def test_owner_cannot_delete_item_that_is_not_available(self) -> None:
+        item = self.create_item(status=ItemStatus.REQUESTED)
+
+        self.client.force_login(self.owner)
+        response = self.client.post(reverse("item-delete", args=[item.pk]))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            reverse("item-detail", args=[item.pk]),
+        )
+        item.refresh_from_db()
+        self.assertIsNone(item.deleted_at)

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -100,7 +100,10 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
     # AbstractUser or AnonymousUser, which we *would* comply with
     # here (BorrowdUser subclasses AbstractUser).
     user: BorrowdUser = request.user  # type: ignore[assignment]
-    item = get_object_or_404(Item, pk=pk, deleted_at__isnull=True)
+    item = get_object_or_404(
+        Item,
+        pk=pk,
+    )
 
     # Not currently differentiating between viewing and borrowing
     # permissions; assumed that if a user can "see" an item (and
@@ -186,19 +189,9 @@ class ItemCreateView(
         return reverse("item-detail", args=[self.object.pk])
 
 
-class ActiveItemQuerySetMixin:
-    """
-    Mixin to filter out deleted items from querysets in item views.
-    """
-
-    def get_queryset(self):  # type: ignore[no-untyped-def]
-        queryset = super().get_queryset()  # type: ignore[misc]
-        return queryset.filter(deleted_at__isnull=True)
-
-
 class ItemDeleteView(
     LoginOr404PermissionMixin,
-    ActiveItemQuerySetMixin,
+    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DeleteView[Item, ModelForm[Item]],
 ):
@@ -227,7 +220,7 @@ class ItemDeleteView(
 
 class ItemDetailView(
     LoginOr404PermissionMixin,
-    ActiveItemQuerySetMixin,
+    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DetailView[Item],
 ):
@@ -291,7 +284,6 @@ class ItemListView(
         context["item_cards"] = build_item_cards_for_items(items, user, "search")
         context["user_has_items"] = Item.objects.filter(
             owner=user,
-            deleted_at__isnull=True,
         ).exists
 
         return context
@@ -299,7 +291,7 @@ class ItemListView(
 
 class ItemUpdateView(
     LoginOr404PermissionMixin,
-    ActiveItemQuerySetMixin,
+    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     UpdateView[Item, ItemForm],
 ):
@@ -378,11 +370,7 @@ class ItemPhotoCreateView(
     form_class = ItemPhotoForm
 
     def get_permission_object(self):  # type: ignore[no-untyped-def]
-        return get_object_or_404(
-            Item,
-            pk=self.kwargs["item_pk"],
-            deleted_at__isnull=True,
-        )
+        return get_object_or_404(Item, pk=self.kwargs["item_pk"])
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -191,7 +191,6 @@ class ItemCreateView(
 
 class ItemDeleteView(
     LoginOr404PermissionMixin,
-    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DeleteView[Item, ModelForm[Item]],
 ):
@@ -220,7 +219,6 @@ class ItemDeleteView(
 
 class ItemDetailView(
     LoginOr404PermissionMixin,
-    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DetailView[Item],
 ):
@@ -291,7 +289,6 @@ class ItemListView(
 
 class ItemUpdateView(
     LoginOr404PermissionMixin,
-    # ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     UpdateView[Item, ItemForm],
 ):

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, cast
 
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
 from django.core.validators import FileExtensionValidator
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
@@ -34,7 +34,7 @@ from .forms import (
     ItemPhotoForm,
     validate_image_size,
 )
-from .models import Item, ItemAction, ItemPhoto
+from .models import Item, ItemAction, ItemPhoto, ItemStatus
 
 
 def _build_item_action_success_message(item_name: str, action: ItemAction) -> str:
@@ -100,7 +100,7 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
     # AbstractUser or AnonymousUser, which we *would* comply with
     # here (BorrowdUser subclasses AbstractUser).
     user: BorrowdUser = request.user  # type: ignore[assignment]
-    item = Item.objects.get(pk=pk)
+    item = get_object_or_404(Item, pk=pk, deleted_at__isnull=True)
 
     # Not currently differentiating between viewing and borrowing
     # permissions; assumed that if a user can "see" an item (and
@@ -186,8 +186,19 @@ class ItemCreateView(
         return reverse("item-detail", args=[self.object.pk])
 
 
+class ActiveItemQuerySetMixin:
+    """
+    Mixin to filter out deleted items from querysets in item views.
+    """
+
+    def get_queryset(self):  # type: ignore[no-untyped-def]
+        queryset = super().get_queryset()  # type: ignore[misc]
+        return queryset.filter(deleted_at__isnull=True)
+
+
 class ItemDeleteView(
     LoginOr404PermissionMixin,
+    ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DeleteView[Item, ModelForm[Item]],
 ):
@@ -196,9 +207,27 @@ class ItemDeleteView(
     success_url = reverse_lazy("item-list")
     http_method_names = ["post"]
 
+    def form_valid(self, form: ModelForm[Item]) -> HttpResponse:
+        item: Item = self.object
+
+        if item.status != ItemStatus.AVAILABLE:
+            _add_message_safe(
+                self.request,
+                messages.ERROR,
+                "Only available items can be deleted.",
+            )
+            return redirect("item-detail", pk=item.pk)
+
+        user = cast(BorrowdUser, self.request.user)
+
+        item.soft_delete(user)
+        _add_message_safe(self.request, messages.SUCCESS, "Item deleted.")
+        return redirect(self.get_success_url())
+
 
 class ItemDetailView(
     LoginOr404PermissionMixin,
+    ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     DetailView[Item],
 ):
@@ -260,13 +289,17 @@ class ItemListView(
         # Build card contexts for all items
         items = list(context["object_list"])
         context["item_cards"] = build_item_cards_for_items(items, user, "search")
-        context["user_has_items"] = Item.objects.filter(owner=user).exists
+        context["user_has_items"] = Item.objects.filter(
+            owner=user,
+            deleted_at__isnull=True,
+        ).exists
 
         return context
 
 
 class ItemUpdateView(
     LoginOr404PermissionMixin,
+    ActiveItemQuerySetMixin,
     BorrowdTemplateFinderMixin,
     UpdateView[Item, ItemForm],
 ):
@@ -345,7 +378,11 @@ class ItemPhotoCreateView(
     form_class = ItemPhotoForm
 
     def get_permission_object(self):  # type: ignore[no-untyped-def]
-        return Item.objects.get(pk=self.kwargs["item_pk"])
+        return get_object_or_404(
+            Item,
+            pk=self.kwargs["item_pk"],
+            deleted_at__isnull=True,
+        )
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -197,6 +197,7 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     owned_items_available = Item.objects.filter(
         owner=user,
         status=ItemStatus.AVAILABLE,
+        deleted_at__isnull=True,
     ).prefetch_related("photos")
 
     # Build card context

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -197,7 +197,6 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     owned_items_available = Item.objects.filter(
         owner=user,
         status=ItemStatus.AVAILABLE,
-        deleted_at__isnull=True,
     ).prefetch_related("photos")
 
     # Build card context


### PR DESCRIPTION
## Summary
Allows users to delete available items they own, even when those items have transaction history, by soft-deleting items and making active items the default query behavior.

## Linked Issue(s)
Closes #343 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- Updated item deletion to set `deleted_at` and `deleted_by` instead of hard-deleting the item row, preserving protected transaction history.
- Added an item manager/queryset so `Item.objects` returns active, non-deleted items by default.
- Added `Item.all_objects` for cases that need access to soft-deleted item records.
- Updated item views, filters, and inventory behavior to align with soft-delete semantics.
- Added regression tests for deleting available owned items with transaction history and preventing deletion of unavailable items.

## How to Test
1.  Manually create/request/cancel or reject an item so it has transaction history and is `AVAILABLE`.
2. Manually create/request/cancel or reject an item so it has transaction history and is `AVAILABLE`.
3. Confirm the owner can delete the item.
4. Confirm the deleted item no longer appears in inventory/search and its detail page is not accessible.

## Screenshots (if UI change)
N/A

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
This changes the default `Item.objects` behavior to exclude soft-deleted items. Code paths that intentionally need deleted item records should use `Item.all_objects`. 
**Need confirmation on whether In-flight (non-available) items can be deleted too ?**