### PR TITLE
Feat/GitHub actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: Lint, format, type-check, template-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - run: uv sync --frozen
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Runs every hook defined in .pre-commit-config.yaml
+      - run: uvx pre-commit run --all-files --show-diff-on-failure
+
+  test:
+    name: Django tests (Postgres 17)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: borrowd
+          POSTGRES_PASSWORD: borrowd
+          POSTGRES_DB: borrowd
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U borrowd"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DJANGO_SETTINGS_MODULE: borrowd.config.ci.django
+      DJANGO_SECRET_KEY: ci-not-a-real-secret
+      BORROWD_BETA_ENABLED: "False"
+      DB_NAME: borrowd
+      DB_USER: borrowd
+      DB_PASSWORD: borrowd
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      # Mirrors(mostly) .platform.app.yaml -> hooks.build
+      - run: uv sync --frozen
+      - run: npm ci
+      - run: npm run build
+      - run: uv run manage.py collectstatic --noinput
+
+      # Mirrors .platform.app.yaml -> hooks.deploy
+      - run: uv run manage.py migrate
+
+      # Mirrors .platform.app.yaml -> hooks.post_deploy
+      - run: uv run manage.py loaddata items/item_categories
+
+      - run: uv run manage.py test

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ coverage.xml
 .cursorrules
 skills-lock.json
 *-langserver
+.claude/settings.local.json
 
 # macOS
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
         additional_dependencies: [
             pytest==8.3.3,
             sqlalchemy==2.0.36,
-            django-stubs==5.1.3
+            django-stubs==5.1.3,
+            pillow==12.2.0
         ]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/borrowd/config/ci/django.py
+++ b/borrowd/config/ci/django.py
@@ -1,0 +1,23 @@
+from borrowd.config.env import env
+
+from ..base import *  # noqa: F403
+
+STATIC_ROOT = BASE_DIR / "staticfiles"  # noqa: F405
+
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": False,
+        "manifest_path": BASE_DIR / "build" / "manifest.json",  # noqa: F405
+    }
+}
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": env("DB_NAME", default="borrowd"),
+        "USER": env("DB_USER", default="borrowd"),
+        "PASSWORD": env("DB_PASSWORD", default="borrowd"),
+        "HOST": env("DB_HOST", default="127.0.0.1"),
+        "PORT": env("DB_PORT", default="5432"),
+    }
+}

--- a/borrowd_groups/models.py
+++ b/borrowd_groups/models.py
@@ -89,7 +89,7 @@ class BorrowdGroup(Model):
         null=True,
         blank=True,
     )
-    membership_requires_approval: BooleanField[Never, Never] = BooleanField(
+    membership_requires_approval: BooleanField[bool, bool] = BooleanField(
         default=True,
         help_text="New members require Moderator approval to join the group",
     )

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -483,7 +483,7 @@ def get_memberships_with_pending_actions(memberships: list[Membership]) -> set[i
     Only groups where the user is a moderator are considered, and only groups
     that actually have at least one PENDING membership are returned.
     """
-    moderator_group_ids = [m.group_id for m in memberships if m.is_moderator]
+    moderator_group_ids = [m.group_id for m in memberships if m.is_moderator]  # type: ignore[attr-defined]
     if not moderator_group_ids:
         return set()
     return set(

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -474,6 +474,7 @@ class GroupJoinView(LoginRequiredMixin, View):  # type: ignore[misc]
         # Redirect to the group detail page
         return redirect("borrowd_groups:group-detail", pk=group.pk)
 
+
 def get_memberships_with_pending_actions(memberships: list[Membership]) -> set[int]:
     """
     Given a list of Membership objects, returns the set of group IDs for which
@@ -492,6 +493,7 @@ def get_memberships_with_pending_actions(memberships: list[Membership]) -> set[i
             status=MembershipStatus.PENDING,
         ).values_list("group_id", flat=True)
     )
+
 
 # No typing for django_filter, so mypy doesn't like us subclassing.
 class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
@@ -525,7 +527,8 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
             setattr(
                 membership,
                 "has_pending_actions",
-                membership.is_moderator and membership.group_id in pending_action_group_ids,
+                membership.is_moderator
+                and membership.group_id in pending_action_group_ids,
             )
 
         context["object_list"] = memberships

--- a/borrowd_items/tests/test_photo_orientation.py
+++ b/borrowd_items/tests/test_photo_orientation.py
@@ -47,13 +47,20 @@ class ItemPhotoOrientationTests(TestCase):
             name="Orientation Test Item",
             description="Used for photo orientation tests",
             owner=cls.owner,
+            created_by=cls.owner,
+            updated_by=cls.owner,
             trust_level_required=TrustLevel.STANDARD,
         )
 
     def test_phone_exif_orientation_is_applied_to_processed_image(self) -> None:
         uploaded_image = build_uploaded_image(width=300, height=500, exif_orientation=6)
 
-        item_photo = ItemPhoto.objects.create(item=self.item, image=uploaded_image)
+        item_photo = ItemPhoto.objects.create(
+            item=self.item,
+            image=uploaded_image,
+            created_by=self.owner,
+            updated_by=self.owner,
+        )
 
         with Image.open(item_photo.image) as processed_image:
             self.assertEqual(processed_image.size, (1600, 960))
@@ -64,7 +71,12 @@ class ItemPhotoOrientationTests(TestCase):
     def test_upload_without_orientation_metadata_keeps_pixel_orientation(self) -> None:
         uploaded_image = build_uploaded_image(width=300, height=500)
 
-        item_photo = ItemPhoto.objects.create(item=self.item, image=uploaded_image)
+        item_photo = ItemPhoto.objects.create(
+            item=self.item,
+            image=uploaded_image,
+            created_by=self.owner,
+            updated_by=self.owner,
+        )
 
         with Image.open(item_photo.image) as processed_image:
             self.assertEqual(processed_image.size, (960, 1600))

--- a/borrowd_items/tests/test_photo_orientation.py
+++ b/borrowd_items/tests/test_photo_orientation.py
@@ -34,6 +34,9 @@ def build_uploaded_image(
 
 
 class ItemPhotoOrientationTests(TestCase):
+    owner: BorrowdUser
+    item: Item
+
     @classmethod
     def setUpTestData(cls) -> None:
         cls.owner = BorrowdUser.objects.create(

--- a/borrowd_items/tests/test_photo_size_validation.py
+++ b/borrowd_items/tests/test_photo_size_validation.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
 from django.test import TestCase
 from django.utils.datastructures import MultiValueDict
-from PIL import Image  # type: ignore[import-not-found]
+from PIL import Image
 
 from borrowd.models import TrustLevel
 from borrowd_items.forms import (

--- a/templates/groups/group_list_card.html
+++ b/templates/groups/group_list_card.html
@@ -1,123 +1,96 @@
-<div
-  id="groups-card-container"
-  class="rounded-2xl shadow-md bg-white overflow-hidden"
->
-  <!-- Header -->
-  <div
-    class="flex items-center gap-3 px-2.5 py-2.5 bg-white border-b border-gray-200"
-  >
-    <div class="label flex-1">
-      <span class="text-xs font-semibold text-base-content-scale-70">
-        Group & trust level
-      </span>
-    </div>
-    <div class="label">
-      <span class="text-xs font-semibold text-base-content-scale-70">
-        Members
-      </span>
-    </div>
-  </div>
-
-  <!-- Group List -->
-  {% for membership in object_list %}
-  <div
-    class="flex items-center gap-3 px-2.5 py-2.5 bg-white {% if not forloop.last %}border-b border-gray-200{% endif %}"
-  >
-    <!-- Group Banner -->
-    <div class="flex-shrink-0 w-12 h-12 overflow-hidden rounded-md">
-      {% if membership.group.banner %}
-      <img
-        class="w-full h-full object-cover"
-        src="{{ membership.group.banner.url }}"
-        alt="{{ membership.group.name }} Banner"
-      />
-      {% else %}
-      <div class="w-full h-full bg-gray-200 flex items-center justify-center">
-        <svg
-          class="w-6 h-6 text-gray-400"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-          ></path>
-        </svg>
-      </div>
-      {% endif %}
+<div id="groups-card-container"
+     class="rounded-2xl shadow-md bg-white overflow-hidden">
+    <!-- Header -->
+    <div class="flex items-center gap-3 px-2.5 py-2.5 bg-white border-b border-gray-200">
+        <div class="label flex-1">
+            <span class="text-xs font-semibold text-base-content-scale-70">
+                Group & trust level
+            </span>
+        </div>
+        <div class="label">
+            <span class="text-xs font-semibold text-base-content-scale-70">
+                Members
+            </span>
+        </div>
     </div>
 
-    <!-- Group Info -->
-    <div class="flex-1 flex flex-col gap-3 min-w-0">
-      <div class="flex items-center">
-        {% if membership.status == "PENDING" %}
-        <span
-          class="text-base font-semibold text-yellow-700 cursor-pointer hover:underline truncate"
-          onclick="
-            window.showToast &&
-              window.showToast('Your request is still pending.', 'warning')
-          "
-          title="Your request is still pending."
-          style="pointer-events: auto"
-        >
-          {{ membership.group.name }}
-        </span>
-        {% else %}
-        <a
-          href="{% url 'borrowd_groups:group-detail' membership.group.pk %}"
-          class="text-base font-semibold text-base-content hover:underline truncate"
-        >
-          {{ membership.group.name }}
-        </a>
-        {% endif %} {% if membership.status == "PENDING" %}
-        <span
-          class="inline-block badge badge-warning badge-soft text-xs px-2 py-1 rounded font-semibold ml-2 align-middle"
-        >
-          Pending
-        </span>
-        {% endif %}
-      </div>
+    <!-- Group List -->
+    {% for membership in object_list %}
+        <div class="flex items-center gap-3 px-2.5 py-2.5 bg-white {% if not forloop.last %}border-b border-gray-200{% endif %}">
+            <!-- Group Banner -->
+            <div class="flex-shrink-0 w-12 h-12 overflow-hidden rounded-md">
+                {% if membership.group.banner %}
+                    <img class="w-full h-full object-cover"
+                         src="{{ membership.group.banner.url }}"
+                         alt="{{ membership.group.name }} Banner" />
+                {% else %}
+                    <div class="w-full h-full bg-gray-200 flex items-center justify-center">
+                        <svg class="w-6 h-6 text-gray-400"
+                             fill="none"
+                             stroke="currentColor"
+                             viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z">
+                            </path>
+                        </svg>
+                    </div>
+                {% endif %}
+            </div>
 
-      <c-trust-level-badge level="{{ membership.get_trust_level_display }}" />
-    </div>
+            <!-- Group Info -->
+            <div class="flex-1 flex flex-col gap-3 min-w-0">
+                <div class="flex items-center">
+                    {% if membership.status == "PENDING" %}
+                        <span class="text-base font-semibold text-yellow-700 cursor-pointer hover:underline truncate"
+                              onclick=" window.showToast && window.showToast('Your request is still pending.', 'warning') "
+                              title="Your request is still pending."
+                              style="pointer-events: auto">
+                            {{ membership.group.name }}
+                        </span>
+                    {% else %}
+                        <a href="{% url 'borrowd_groups:group-detail' membership.group.pk %}"
+                           class="text-base font-semibold text-base-content hover:underline truncate">
+                            {{ membership.group.name }}
+                        </a>
+                    {% endif %}
 
-    <!-- Member Count -->
-    <div
-      class="text-base font-semibold text-base-content-scale-50 text-right w-10 inline-flex items-center justify-end gap-3"
-    >
-      {{ membership.group.users.count }} {% if membership.has_pending_actions %}
-      <span
-        class="inline-flex items-center justify-center w-5 h-5"
-        title="Pending actions require moderator review"
-        aria-label="Pending actions"
-        data-testid="group-pending-actions-indicator"
-      >
-        {% include "icons/exclamation-circle.svg" %}
-      </span>
-      {% endif %}
-    </div>
-  </div>
-  {% empty %}
-  <div class="flex flex-col gap-5 items-center px-4 py-12">
-    {% load static %}
+                    {% if membership.status == "PENDING" %}
+                        <span class="inline-block badge badge-warning badge-soft text-xs px-2 py-1 rounded font-semibold ml-2 align-middle">
+                            Pending
+                        </span>
+                    {% endif %}
+                </div>
 
-    <img
-      src="{% static 'groups/Groups_2.PNG' %}"
-      alt="Create a group"
-      class="w-72 h-auto"
-    />
-    <p class="text-base text-base-content text-center leading-normal">
-      Add a group to start sharing and borrowing items
-    </p>
-    <c-button-nav
-      url="{% url 'borrowd_groups:group-create' %}"
-      class="btn btn-primary btn-lg"
-    >
-      Create a group
-    </c-button-nav>
-  </div>
-  {% endfor %}
+                <c-trust-level-badge level="{{ membership.get_trust_level_display }}" />
+            </div>
+
+            <!-- Member Count -->
+            <div class="text-base font-semibold text-base-content-scale-50 text-right w-10 inline-flex items-center justify-end gap-3">
+                {{ membership.group.users.count }}
+                {% if membership.has_pending_actions %}
+                    <span class="inline-flex items-center justify-center w-5 h-5"
+                          title="Pending actions require moderator review"
+                          aria-label="Pending actions"
+                          data-testid="group-pending-actions-indicator">
+                        {% include "icons/exclamation-circle.svg" %}
+
+                    </span>
+                {% endif %}
+            </div>
+        </div>
+    {% empty %}
+        <div class="flex flex-col gap-5 items-center px-4 py-12">
+            {% load static %}
+
+            <img src="{% static 'groups/Groups_2.PNG' %}"
+                 alt="Create a group"
+                 class="w-72 h-auto" />
+            <p class="text-base text-base-content text-center leading-normal">
+                Add a group to start sharing and borrowing items
+            </p>
+            <c-button-nav url="{% url 'borrowd_groups:group-create' %}"
+                          class="btn btn-primary btn-lg">
+                Create a group
+            </c-button-nav>
+        </div>
+    {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow (pre-commit hooks + Django tests against Postgres 17) that runs on PRs and pushes/merges to main. 
Also fixes the pre-existing mypy errors that surfaced once pre-commit ran `--all-files` in CI.
Also fixes some forgotten fields in a test.

## Linked Issue(s)
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Configuration / infrastructure

## Changes Made
- `.github/workflows/ci.yml` - new workflow, two jobs: `pre-commit` (runs all hooks) and `test` (Postgres 17 service)
- `borrowd/config/ci/django.py` - inherits `base`, points dbs at the GHA Postgres service via `DB_*` env vars, sets vite to production-manifest mode
- `.pre-commit-config.yaml` - add `pillow==12.2.0` to the mypy hook's additional_dependencies (PIL import-resolution in the mypy env)
- `borrowd_groups/models.py` - fix `membership_requires_approval` field generics;
- `borrowd_groups/views.py` - `# type: ignore[attr-defined]` on `Membership.group_id`. Should be fixed in a follow-up. 
  - I believe this is caused by explicitly assigning a type to the field, which means letting it be auto-assigned is the solution, and is probably a bigger scope than this PR: 
  ```python
  # borrowd_groups/models.py:269
  group: ForeignKey[BorrowdGroup] = ForeignKey(BorrowdGroup, on_delete=CASCADE)
  ```
- `borrowd_items/tests/test_photo_orientation.py` - class-level type annotations
- `borrowd_items/tests/test_photo_size_validation.py` - drop now-unused `# type: ignore[import-not-found]` on PIL
- `templates/groups/group_list_card.html` - djlint autofix

## How to Test
1. Pull the branch, run `uvx pre-commit run --all-files` — should be green.
2. After push, check the PR's Checks tab — both `pre-commit` and `test` jobs should pass.

## Screenshots (if UI change)
N/A

## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
N/A