### PR TITLE
Fix/ci failures

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -34,16 +34,16 @@ from .processors import AutoOrientProcessor
 
 
 class ActiveItemQuerySet(QuerySet["Item"]):
-    def active(self):  # type: ignore[no-untyped-def]
+    def active(self) -> "ActiveItemQuerySet":
         return self.filter(deleted_at__isnull=True)
 
-    def deleted(self):  # type: ignore[no-untyped-def]
+    def deleted(self) -> "ActiveItemQuerySet":
         return self.filter(deleted_at__isnull=False)
 
 
-class ActiveItemManager(models.Manager.from_queryset(ActiveItemQuerySet)):  # type: ignore[misc]
-    def get_queryset(self):  # type: ignore[no-untyped-def]
-        return super().get_queryset().active()
+class ActiveItemManager(models.Manager["Item"]):
+    def get_queryset(self) -> ActiveItemQuerySet:
+        return ActiveItemQuerySet(self.model, using=self._db).active()
 
 
 class ItemAction(TextChoices):

--- a/borrowd_items/tests/test_item_deletion.py
+++ b/borrowd_items/tests/test_item_deletion.py
@@ -48,7 +48,7 @@ class ItemDeletionTests(TestCase):
         response = self.client.post(reverse("item-delete", args=[item.pk]))
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], reverse("item-list"))
+        self.assertEqual(response["Location"], reverse("profile-inventory"))
         item.refresh_from_db()
         transaction.refresh_from_db()
         self.assertIsNotNone(item.deleted_at)


### PR DESCRIPTION
## Summary
Fix CI failures introduced by recent merges to main.

## Linked Issue(s)
N/A

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- `borrowd_items/models.py` — re-typed `ActiveItemManager` as `Manager["Item"]` so `Item.objects.create()` returns `Item` instead of `Any`.
- `borrowd_items/tests/test_item_deletion.py` — updated redirect assertion from `item-list` to `profile-inventory` to match the new `ItemDeleteView.success_url`.

## How to Test
1. `uvx pre-commit run --all-files` — passes.
2. `uv run manage.py test` — all tests pass

## Screenshots (if UI change)
N/A

## Checklist
- [X] I have tested this locally
- [X] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [X] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
N/A
