### PR TITLE
memory management fixes for image uploads

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -52,7 +52,7 @@ web:
     # The command to launch your app. If it terminates, it’s restarted immediately.
     #
     # using gunicorn as opposed to uvi/hypercorn or daphne since we do not make use of async or websockets right now
-    start: "uv run gunicorn -w 4 -b unix:$SOCKET borrowd.wsgi:application"
+    start: "uv run gunicorn -w 2 -b unix:$SOCKET borrowd.wsgi:application"
 
   # More information: https://docs.platform.sh/configuration/app-containers.html#upstream
   upstream:

--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -243,6 +243,10 @@ BETA_COOKIE_DOMAIN: str | None = None
 BETA_SECURE_COOKIE: bool = False
 BETA_COOKIE_SAMESITE = "Lax"
 
+# tuning uploads settings
+DATA_UPLOAD_MAX_MEMORY_SIZE = 1024 * 1024  # 1MB
+FILE_UPLOAD_MAX_MEMORY_SIZE = 1024 * 1024  # 1MB
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->
Addresses some immediate issues with image uploads.

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #477

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- reduce number of gunicorn workers from 4 to 2
- set max upload size before streaming files to temporary storage

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Upload 5 images (>2MB) simultaneously to an item
2. Hopefully it doesn't crash

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [ ] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
