### PR TITLE
toast messages appear stacked

### DIFF
--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -1,15 +1,16 @@
 {% load i18n heroicons %}
 
 {% if messages %}
-    {% for message in messages %}
-        <div x-data
-             x-init="setTimeout(() => { $el.style.transition = 'opacity 0.3s ease-out'; $el.style.opacity = '0'; setTimeout(() => $el.remove(), 300); }, 5000)"
-             class="toast toast-center z-50">
-            <div role="alert"
-                 class="alert alert-{{ message.tags }} w-72 flex items-center gap-4 px-4 py-3 rounded-2xl shadow-[0px_4px_3px_-2px_rgba(0,0,0,0.08)] font-bold">
-                {% heroicon_outline "information-circle" class="w-6 h-6 shrink-0" stroke_width=1.5 %}
-                <span class="text-sm leading-6">{{ message }}</span>
+    <div class="toast toast-center items-center z-50 flex flex-col gap-y-2 w-full max-w-xs">
+        {% for message in messages %}
+            <div x-data
+                 x-init="setTimeout(() => { $el.style.transition = 'opacity 0.3s ease-out'; $el.style.opacity = '0'; setTimeout(() => $el.remove(), 300); }, 5000)">
+                <div role="alert"
+                     class="alert alert-{{ message.tags }} w-72 flex items-center gap-4 px-4 py-3 rounded-2xl shadow-[0px_4px_3px_-2px_rgba(0,0,0,0.08)] font-bold">
+                    {% heroicon_outline "information-circle" class="w-6 h-6 shrink-0" stroke_width=1.5 %}
+                    <span class="text-sm leading-6">{{ message }}</span>
+                </div>
             </div>
-        </div>
-    {% endfor %}
+        {% endfor %}
+    </div>
 {% endif %}


### PR DESCRIPTION
## Summary
If multiple toast messaged were triggered at the same time, they overlapped each other.

## Linked Issue(s)
Closes #476 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- Updated the styling for the toast notifications in messages.html : 
-

## How to Test
1. see #476 
2.

## Screenshots (if UI change)
<!-- Before / After if applicable -->
Before:
<img width="453" height="135" alt="Screenshot 2026-05-27 at 2 52 47 PM" src="https://github.com/user-attachments/assets/20a68bb5-e975-4afc-a476-2a5d319bd743" />

After:
<img width="259" height="123" alt="Screenshot 2026-05-27 at 2 54 39 PM" src="https://github.com/user-attachments/assets/a45f193a-fbd3-4f11-a152-8981e5916709" />


## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [x] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
