### PR TITLE
design for group approuval toast message

### DIFF
--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -687,10 +687,7 @@ class ApproveMemberView(LoginRequiredMixin, View):  # type: ignore[misc]
         membership.status = MembershipStatus.ACTIVE
         membership.save(update_fields=["status"])
 
-        messages.success(
-            request,
-            f"{membership.user.profile.full_name()} has been approved.",  # type: ignore[attr-defined]
-        )
+        messages.success(request, "Request approved.")
         return redirect("borrowd_groups:group-detail", pk=membership.group.pk)  # type: ignore[attr-defined]
 
 
@@ -713,10 +710,7 @@ class DenyMemberView(LoginRequiredMixin, View):  # type: ignore[misc]
             raise PermissionDenied
 
         membership.delete()
-        messages.success(
-            request,
-            f"{membership.user.profile.full_name()} has been denied.",  # type: ignore[attr-defined]
-        )
+        messages.info(request, "Request denied.")
         return redirect("borrowd_groups:group-detail", pk=membership.group.pk)  # type: ignore[attr-defined]
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -92,4 +92,9 @@ TODO: Transfer over all to daisy */
     color: var(--color-warning-content);
     border-color: var(--color-warning);
   }
+  .alert-info {
+    background-color: var(--color-info);
+    color: var(--color-info-content);
+    border-color: var(--color-info)
+  }
 }


### PR DESCRIPTION
## Summary
Change the styling for info messages to match custom colouring instead of default.

## Linked Issue(s)
Closes #419 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- Removed the name in the conformation message inside the group view
- Added a custom alert-info class to match the figma design 

## How to Test
1. approve or deny a request to join a group
2.

## Screenshots (if UI change)
Before:
<img width="285" height="65" alt="Screenshot 2026-05-27 at 2 48 50 PM" src="https://github.com/user-attachments/assets/5fd85e98-6893-4c71-a92b-9bd23be62879" />
<img width="377" height="109" alt="Screenshot 2026-05-27 at 2 48 45 PM" src="https://github.com/user-attachments/assets/652b7813-67e4-492b-9da9-a5a4df053a67" />
After:
<img width="372" height="98" alt="Screenshot 2026-05-27 at 2 51 03 PM" src="https://github.com/user-attachments/assets/e3d4fbcd-3c22-4f88-b0c1-2bb07bf3e23d" />
<img width="400" height="117" alt="Screenshot 2026-05-27 at 2 50 44 PM" src="https://github.com/user-attachments/assets/6c7fa3a7-6ffe-4eaf-8ce8-9d433faa767d" />


## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [x] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
