### PR TITLE
fix(items): order filtered item list for stable pagination

### DIFF
--- a/borrowd_items/filters.py
+++ b/borrowd_items/filters.py
@@ -79,7 +79,8 @@ class ItemFilter(FilterSet):  # type: ignore[misc]
                 # ensure form validation before filtering
                 self.errors
                 qs = self.filter_queryset(qs)
-            self._qs = qs
+            # Stable ordering keeps page boundaries deterministic; pk breaks created_at ties.
+            self._qs = qs.order_by("-created_at", "-pk")
         return self._qs
 
     class Meta:

--- a/borrowd_items/tests/test_item_pagination.py
+++ b/borrowd_items/tests/test_item_pagination.py
@@ -130,6 +130,24 @@ class ItemListPaginationTests(TestCase):
         self.assertContains(response, "page_size=6")
         self.assertContains(response, "page=2")
 
+    def test_pages_are_ordered_newest_first_without_overlap(self) -> None:
+        """Pages follow newest-first ordering; no item repeats or goes missing."""
+        items = [
+            self.create_item(name=f"Item {i}", description=f"Desc {i}")
+            for i in range(8)
+        ]
+        expected_pks = sorted((item.pk for item in items), reverse=True)
+
+        self.client.force_login(self.viewer)
+        page1 = self.client.get(reverse("item-list"), {"page_size": "6"})
+        page2 = self.client.get(reverse("item-list"), {"page_size": "6", "page": "2"})
+
+        page1_pks = [card["pk"] for card in page1.context["item_cards"]]
+        page2_pks = [card["pk"] for card in page2.context["item_cards"]]
+
+        self.assertEqual(page1_pks, expected_pks[:6])
+        self.assertEqual(page2_pks, expected_pks[6:])
+
     def test_no_pagination_when_few_items(self) -> None:
         """Single page when item count is below the page size."""
         for i in range(3):


### PR DESCRIPTION
## Summary
Adds a stable ordering (`-created_at`, `-pk`) to the filtered item list queryset so pagination is deterministic. Silences the `UnorderedObjectListWarning` Django raises in test runs.

## Linked Issue(s)
Closes #500

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- `borrowd_items/filters.py`: `ItemFilter.qs` now orders by `-created_at`, `-pk` (newest first; pk breaks same-instant ties).
- `borrowd_items/tests/test_item_pagination.py`: tests pages are newest-first with no overlap or gaps across pages

## How to Test
- `uv run manage.py test borrowd_items.tests.test_item_pagination`; all tests pass no warning visible

## Screenshots (if UI change)
N/A

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
N/A