### PR TITLE
added upload loading state and tests

### DIFF
--- a/borrowd_items/tests/test_photo_size_validation.py
+++ b/borrowd_items/tests/test_photo_size_validation.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from typing import Any, cast
 
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.utils.datastructures import MultiValueDict
 from PIL import Image
 
@@ -25,6 +25,7 @@ from borrowd_items.forms import (
     validate_image_size,
 )
 from borrowd_items.models import Item, ItemCategory
+from borrowd_items.views import ItemUpdateView
 from borrowd_users.models import BorrowdUser
 
 
@@ -66,6 +67,40 @@ def make_files(
 def make_empty_files() -> MultiValueDict[str, UploadedFile]:
     """Create an empty files dict for form testing."""
     return cast(MultiValueDict[str, UploadedFile], {})
+
+
+class ItemUpdatePhotoProcessingTests(TestCase):
+    def test_corrupt_pending_photo_is_skipped_without_raising(self) -> None:
+        owner = BorrowdUser.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="password",
+        )
+        item = Item.objects.create(
+            name="Test item",
+            description="Test description",
+            owner=owner,
+            created_by=owner,
+            updated_by=owner,
+            trust_level_required=TrustLevel.STANDARD,
+        )
+        corrupt_photo = SimpleUploadedFile(
+            name="corrupt.jpg",
+            content=b"not an image",
+            content_type="image/jpeg",
+        )
+        request = RequestFactory().post(
+            "/items/1/edit/",
+            data={"new_photos": corrupt_photo},
+        )
+        request.user = owner
+        view = ItemUpdateView()
+        view.request = request
+        view.object = item
+
+        view._process_uploaded_photos()
+
+        self.assertEqual(item.photos.count(), 0)
 
 
 class ValidateImageSizeFunctionTests(TestCase):

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -3,11 +3,12 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
-from django.core.validators import FileExtensionValidator
+from django.core.files.uploadedfile import UploadedFile
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
+from django.utils.datastructures import MultiValueDict
 from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 from django_filters.views import FilterView
@@ -30,11 +31,9 @@ from .exceptions import InvalidItemAction, ItemAlreadyRequested
 from .filters import ItemFilter
 from .forms import (
     ALLOWED_IMAGE_ACCEPT,
-    ALLOWED_IMAGE_EXTENSIONS,
     ItemCreateWithPhotoForm,
     ItemForm,
     ItemPhotoForm,
-    validate_image_size,
 )
 from .models import Item, ItemAction, ItemPhoto, ItemStatus
 
@@ -370,24 +369,19 @@ class ItemUpdateView(
         item: Item = self.object
         remaining_slots = 5 - item.photos.count()
 
-        ext_validator = FileExtensionValidator(
-            allowed_extensions=ALLOWED_IMAGE_EXTENSIONS
-        )
         skipped = 0
 
         for upload in uploaded_files[:remaining_slots]:
-            try:
-                ext_validator(upload)
-                validate_image_size(upload)
-            except Exception:
+            photo_files = MultiValueDict[str, UploadedFile]({"image": [upload]})
+            photo_form = ItemPhotoForm(files=photo_files)
+            if not photo_form.is_valid():
                 skipped += 1
                 continue
-            ItemPhoto.objects.create(
-                item=item,
-                image=upload,
-                created_by=self.request.user,
-                updated_by=self.request.user,
-            )
+            photo = photo_form.save(commit=False)
+            photo.item = item
+            photo.created_by = self.request.user
+            photo.updated_by = self.request.user
+            photo.save()
 
         if skipped:
             _add_message_safe(

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -372,7 +372,9 @@ class ItemUpdateView(
         skipped = 0
 
         for upload in uploaded_files[:remaining_slots]:
-            photo_files = MultiValueDict[str, UploadedFile]({"image": [upload]})
+            photo_files: MultiValueDict[str, UploadedFile] = MultiValueDict(
+                {"image": [upload]}
+            )
             photo_form = ItemPhotoForm(files=photo_files)
             if not photo_form.is_valid():
                 skipped += 1

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -68,6 +68,27 @@ TODO: Transfer over all to daisy */
   --color-borrowd-light-gray: #e6e6ed;
 }
 @layer utilities {
+  @keyframes photo-upload-shimmer {
+    from {
+      transform: translateY(110%);
+    }
+    to {
+      transform: translateY(-110%);
+    }
+  }
+
+  .photo-upload-shimmer {
+    background: linear-gradient(to top, transparent 20%, rgb(255 255 255 / 65%) 50%, transparent 80%);
+    animation: photo-upload-shimmer 1.6s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .photo-upload-shimmer {
+      animation: none;
+      display: none;
+    }
+  }
+
   .btn-waitlisted {
     --btn-fg: #6B7280;
     --btn-bg: rgb(156 163 175 / 0.15);

--- a/templates/items/item_form.html
+++ b/templates/items/item_form.html
@@ -23,7 +23,8 @@
         <form method="post"
               enctype="multipart/form-data"
               class="bg-primary-content rounded-2xl border border-base-200 shadow-sm p-6 flex flex-col gap-4"
-              onsubmit="this.querySelector('button[type=submit]').disabled = true;">
+              x-data="{ isSubmitting: false, submitForm(event) { if (this.isSubmitting) { event.preventDefault(); return; } this.isSubmitting = true; } }"
+              @submit="submitForm($event)">
             {% csrf_token %}
 
             {% for field in form %}
@@ -181,10 +182,14 @@
                             {# Pending previews — shown immediately, saved on form submit #}
                             <template x-for="(preview, index) in pendingPreviews" :key="index">
                                 <div class="border border-dashed border-base-content/30 rounded flex flex-col items-center pb-2 overflow-hidden w-full max-w-[96px] relative">
-                                    <div class="w-full aspect-square overflow-hidden rounded-t">
+                                    <div class="relative w-full aspect-square overflow-hidden rounded-t">
                                         <img :src="preview"
                                              alt="Pending upload"
                                              class="w-full h-full object-cover" />
+                                        <span x-show="isSubmitting"
+                                              x-cloak
+                                              class="photo-upload-shimmer absolute inset-0 pointer-events-none"
+                                              aria-hidden="true"></span>
                                     </div>
                                     <span class="absolute top-1 right-1 bg-base-content/70 text-base-100 text-[9px] font-semibold px-1 py-px rounded leading-none">New</span>
                                     <button type="button"
@@ -242,11 +247,11 @@
                     <c-button-nav url="{% url 'item-detail' form.instance.pk %}" class="btn">
                         Cancel
                     </c-button-nav>
-                    <c-button type="submit" class="btn btn-primary">
+                    <c-button type="submit" class="btn btn-primary" x-bind:disabled="isSubmitting">
                         Save changes
                     </c-button>
                 {% else %}
-                    <c-button type="submit" class="btn btn-primary">
+                    <c-button type="submit" class="btn btn-primary" x-bind:disabled="isSubmitting">
                         Add item
                     </c-button>
                 {% endif %}
@@ -291,5 +296,28 @@
     </div>
 
     {% include "components/modal.html" with modal_id="trust-level-info-modal" modal_title="Trust levels" modal_size="full" modal_content_template="items/_trust_level_info_content.html" cancel_button_text="Got it" %}
+
+    <style>
+        @keyframes photo-upload-shimmer {
+            from {
+                transform: translateY(110%);
+            }
+            to {
+                transform: translateY(-110%);
+            }
+        }
+
+        .photo-upload-shimmer {
+            background: linear-gradient(to top, transparent 20%, rgb(255 255 255 / 65%) 50%, transparent 80%);
+            animation: photo-upload-shimmer 1.6s ease-in-out infinite;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .photo-upload-shimmer {
+                animation: none;
+                display: none;
+            }
+        }
+    </style>
 
 {% endblock %}

--- a/templates/items/item_form.html
+++ b/templates/items/item_form.html
@@ -297,27 +297,4 @@
 
     {% include "components/modal.html" with modal_id="trust-level-info-modal" modal_title="Trust levels" modal_size="full" modal_content_template="items/_trust_level_info_content.html" cancel_button_text="Got it" %}
 
-    <style>
-        @keyframes photo-upload-shimmer {
-            from {
-                transform: translateY(110%);
-            }
-            to {
-                transform: translateY(-110%);
-            }
-        }
-
-        .photo-upload-shimmer {
-            background: linear-gradient(to top, transparent 20%, rgb(255 255 255 / 65%) 50%, transparent 80%);
-            animation: photo-upload-shimmer 1.6s ease-in-out infinite;
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-            .photo-upload-shimmer {
-                animation: none;
-                display: none;
-            }
-        }
-    </style>
-
 {% endblock %}


### PR DESCRIPTION
## Summary
Fixes item editing with pending photo uploads by validating images before processing and adds an upward shimmer effect while pending images are uploaded.

### small improvement proposal
When the 5 images threshold is reached, the user have to delete manually and upload new images: 
- We could simply add a replace buttons on the image and handle the deleted implicitly.

## Linked Issue(s)
Closes #475 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- Updated `ItemUpdateView` to validate uploaded photos through `ItemPhotoForm`, preventing invalid images from causing a 500 error.
- Added a per-image shimmer animation shown while pending photos are submitted.
- Added regression coverage for corrupt pending image uploads.

## How to Test
1. Edit an item and select one or more valid photos.
2. Save the item and confirm the shimmer appears while submitting.
3. Confirm the item changes and photos are saved.
4. Submit an invalid or corrupt image and confirm the item changes save without displaying the 500 page.

## Screenshots (if UI change)
Add a screenshot or recording of the pending-image shimmer during save.

https://github.com/user-attachments/assets/f6273a61-fbf4-4b0c-9d72-cd4945cbed1e


## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
No model changes or migrations are required. Review the image validation behavior and pending-thumbnail shimmer timing.