### PR TITLE
Display count of active group members only

### DIFF
--- a/borrowd_groups/filters.py
+++ b/borrowd_groups/filters.py
@@ -51,7 +51,7 @@ class GroupFilter(FilterSet):  # type: ignore[misc]
                 user=self.request.user,
             )
             qs = qs.annotate(
-                active_member_count=Count(
+                active_members_count=Count(
                     "group__membership",
                     filter=Q(group__membership__status=MembershipStatus.ACTIVE),
                     distinct=True,

--- a/templates/groups/group_list_card.html
+++ b/templates/groups/group_list_card.html
@@ -61,7 +61,7 @@
 
             <!-- Member Count -->
             <div class="text-base font-semibold text-base-content-scale-50 text-right w-10 inline-flex items-center justify-end gap-3">
-                {{ membership.group.users.count }}
+                {{ membership.active_members_count }}
 
                 {% if membership.has_pending_actions %}
                     <span class="inline-flex items-center justify-center w-5 h-5 text-info"


### PR DESCRIPTION
## Summary
It looks like [this bugfix](https://github.com/borrowd/borrowd/pull/459) was overridden somewhere before [this commit](https://github.com/borrowd/borrowd/commit/8ef47fee418d3831308b6ed035828aeb6ad5bb1c#diff-94d3b6442e1a94cade9566f5e2226e5f491654aae5d6d080efaf606ab7bbebd6L91). I couldn't find the actual diff where it got reverted.
Reapplying the same fix and changing the filter name.

## Linked Issue(s)
Closes #479 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made 
- Reapply `membership.active_members_count` as the number of member displayed
- Renamed the filter from `active_member_count` to `active_members_count`

## How to Test
1. Navigate to /groups
2. Verify that member count exclude pending members

## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)
