### PR TITLE
Prevent unstyled content flash in local environment 

### DIFF
--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -95,6 +95,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
+                "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",

--- a/borrowd/config/dev/django.py
+++ b/borrowd/config/dev/django.py
@@ -12,6 +12,7 @@ else:
     ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 STATIC_ROOT = BASE_DIR / "staticfiles"  # noqa: F405
+INTERNAL_IPS = ["127.0.0.1"]
 DJANGO_VITE = {
     "default": {
         "dev_mode": DEBUG,

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="color-scheme" content="light" />
         <link rel="icon" href="/favicon.ico" sizes="32x32">
         <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml">
         <title>
@@ -19,6 +20,7 @@
                 src="https://plausible.io/js/script.js"></script>
         {% vite_hmr_client %}
         {% vite_asset 'static/js/main.js' %}
+        {% if debug %}<style id="fouc-guard">body{visibility:hidden}</style><script>document.addEventListener('DOMContentLoaded',function(){var s=document.getElementById('fouc-guard');if(s)s.remove()})</script>{% endif %}
     </head>
     <body x-data
           class="flex flex-col justify-center min-h-screen bg-base-200"

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,6 @@
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta name="color-scheme" content="light" />
         <link rel="icon" href="/favicon.ico" sizes="32x32">
         <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml">
         <title>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,9 @@
                 src="https://plausible.io/js/script.js"></script>
         {% vite_hmr_client %}
         {% vite_asset 'static/js/main.js' %}
-        {% if debug %}<style id="fouc-guard">body{visibility:hidden}</style><script>document.addEventListener('DOMContentLoaded',function(){var s=document.getElementById('fouc-guard');if(s)s.remove()})</script>{% endif %}
+        {% if debug %}
+            <style id="fouc-guard">body{visibility:hidden}</style><script>document.addEventListener('DOMContentLoaded',function(){var s=document.getElementById('fouc-guard');if(s)s.remove()})</script>
+        {% endif %}
     </head>
     <body x-data
           class="flex flex-col justify-center min-h-screen bg-base-200"


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->
In local development the Borrowd logo flashes on the screen between each page load. This is a distracting glitch that easily be fixed by hiding the body element in debug mode until the DOM finishes loading. 
In production, the browser only renders the html when all assets are loaded, so the glitch doesn't happen. However, in  local dev the browser renders the html and after that Vite injects the CSS dynamically at runtime, hence we see what is called FOUC (Flash of Unstyled Content).

## Linked Issue(s)
<!-- Closes #[issue number] -->
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- borrowd/config/base.py - add reference to debug processor
- borrowd/config/dev/django.py - add localhost to IPS list 
- templates/base.html - add temp style tag to hide body

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. In local dev, navigate between pages and verify that there are no styling glitches.

## Screenshots (if UI change)
<!-- Before / After if applicable -->
Before
https://github.com/user-attachments/assets/e1fafa8e-cab4-4031-b024-d15a4d505bf9

After
https://github.com/user-attachments/assets/dc8c486d-4ad3-4f76-a7cd-a1c20e36bcaa

## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
N/A