### PR TITLE
mypy fixes: the penultimate PR.

### DIFF
--- a/borrowd_groups/filters.py
+++ b/borrowd_groups/filters.py
@@ -3,6 +3,8 @@ from typing import Any
 from django.db.models import Count, Q, QuerySet
 from django_filters import BooleanFilter, CharFilter, FilterSet
 
+from borrowd_users.request import get_authenticated_user
+
 from .models import Membership, MembershipStatus
 
 
@@ -48,7 +50,7 @@ class GroupFilter(FilterSet):  # type: ignore[misc]
             qs: QuerySet[Membership] = Membership.objects.select_related(
                 "group"
             ).filter(
-                user=self.request.user,
+                user=get_authenticated_user(self.request),
             )
             qs = qs.annotate(
                 active_members_count=Count(

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -219,7 +219,7 @@ class GroupCreateView(
 
     def get_form_kwargs(self) -> dict[str, Any]:
         kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.request.user
+        kwargs["user"] = get_authenticated_user(self.request)
         return kwargs
 
     def form_valid(self, form: GroupCreateForm) -> HttpResponse:
@@ -527,7 +527,7 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
 
         context["object_list"] = memberships
         context["has_groups"] = Membership.objects.filter(
-            user=self.request.user
+            user=get_authenticated_user(self.request)
         ).exists()
         return context
 
@@ -543,7 +543,7 @@ class GroupUpdateView(
 
     def get_form_kwargs(self) -> dict[str, Any]:
         kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.request.user
+        kwargs["user"] = get_authenticated_user(self.request)
         return kwargs
 
     def form_valid(self, form: GroupUpdateForm) -> HttpResponse:

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -457,7 +457,7 @@ class GroupJoinView(LoginRequiredMixin, View):
 
         # Check if membership_requires_approval, set pending
         membership = group.add_user(
-            request.user,  # type: ignore[arg-type]
+            get_authenticated_user(request),
             trust_level=form.cleaned_data["trust_level"],
         )
         if membership.status == MembershipStatus.PENDING:
@@ -499,9 +499,8 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         term = request.GET.get("search")
         if term is not None:
-            user: BorrowdUser = request.user  # type: ignore[assignment]
             SearchTerm.record_search(
-                user=user,
+                user=get_authenticated_user(request),
                 target=SearchTarget.GROUPS,
                 term=term,
             )
@@ -715,7 +714,7 @@ class LeaveGroupView(LoginRequiredMixin, View):
         self, request: HttpRequest, pk: int
     ) -> HttpResponsePermanentRedirect | HttpResponseRedirect:
         group = get_object_or_404(BorrowdGroup, pk=pk)
-        user: BorrowdUser = request.user  # type: ignore[assignment]
+        user = get_authenticated_user(request)
 
         membership = Membership.objects.filter(
             user=user,
@@ -763,7 +762,7 @@ class BecomeModeratorView(LoginRequiredMixin, View):
     def post(
         self, request: HttpRequest, pk: int
     ) -> HttpResponsePermanentRedirect | HttpResponseRedirect:
-        user: BorrowdUser = request.user  # type: ignore[assignment]
+        user = get_authenticated_user(request)
 
         with transaction.atomic():
             # Lock group row. This prevents race condition (two users clicking)

--- a/borrowd_items/filters.py
+++ b/borrowd_items/filters.py
@@ -5,6 +5,7 @@ from django_filters import CharFilter, FilterSet, ModelMultipleChoiceFilter
 from guardian.shortcuts import get_objects_for_user
 
 from borrowd_permissions.models import ItemOLP
+from borrowd_users.request import get_authenticated_user
 
 from .models import Item, ItemCategory
 
@@ -67,13 +68,13 @@ class ItemFilter(FilterSet):  # type: ignore[misc]
         if not hasattr(self, "_qs"):
             qs: QuerySet[Item] = (
                 get_objects_for_user(
-                    self.request.user,
+                    get_authenticated_user(self.request),
                     ItemOLP.VIEW,
                     klass=Item,
                     with_superuser=False,
                 )
                 .filter(deleted_at__isnull=True)
-                .exclude(owner=self.request.user)
+                .exclude(owner=get_authenticated_user(self.request))
             )
             if self.is_bound:
                 # ensure form validation before filtering

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -20,7 +20,7 @@ from borrowd_permissions.mixins import (
     LoginOr404PermissionMixin,
 )
 from borrowd_permissions.models import ItemOLP
-from borrowd_users.models import BorrowdUser, SearchTarget, SearchTerm
+from borrowd_users.models import SearchTarget, SearchTerm
 from borrowd_users.request import get_authenticated_user
 
 from .card_helpers import (
@@ -234,7 +234,7 @@ class ItemDeleteView(
             )
             return redirect("item-detail", pk=item.pk)
 
-        user = cast(BorrowdUser, self.request.user)
+        user = get_authenticated_user(self.request)
 
         item.soft_delete(user)
         _add_message_safe(self.request, messages.SUCCESS, "Item deleted.")
@@ -251,7 +251,7 @@ class ItemDetailView(
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        user: BorrowdUser = self.request.user
+        user = get_authenticated_user(self.request)
 
         action_context = self.object.get_action_context_for(user=user)
 
@@ -323,7 +323,7 @@ class ItemListView(
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context_data(**kwargs)
-        user: BorrowdUser = self.request.user
+        user = get_authenticated_user(self.request)
 
         # Build card contexts for all items
         items = list(context["object_list"])
@@ -355,7 +355,7 @@ class ItemUpdateView(
         return context
 
     def form_valid(self, form: ItemForm) -> HttpResponse:
-        form.instance.updated_by = self.request.user
+        form.instance.updated_by = get_authenticated_user(self.request)
         response = super().form_valid(form)
         self._process_uploaded_photos()
         _add_message_safe(self.request, messages.SUCCESS, "Changes saved.")
@@ -368,6 +368,7 @@ class ItemUpdateView(
             return
 
         item: Item = self.object
+        user = get_authenticated_user(self.request)
         remaining_slots = 5 - item.photos.count()
 
         ext_validator = FileExtensionValidator(
@@ -385,8 +386,8 @@ class ItemUpdateView(
             ItemPhoto.objects.create(
                 item=item,
                 image=upload,
-                created_by=self.request.user,
-                updated_by=self.request.user,
+                created_by=user,
+                updated_by=user,
             )
 
         if skipped:
@@ -434,9 +435,10 @@ class ItemPhotoCreateView(
 
     def form_valid(self, form: ItemPhotoForm) -> HttpResponse:
         context = self.get_context_data()
+        user = get_authenticated_user(self.request)
         form.instance.item_id = context["item_pk"]
-        form.instance.created_by = self.request.user
-        form.instance.updated_by = self.request.user
+        form.instance.created_by = user
+        form.instance.updated_by = user
         return super().form_valid(form)
 
     def get_success_url(self) -> str:

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -114,11 +114,7 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
     if req_action is None:
         return HttpResponse("No action specified.", status=400)
 
-    # mypy complains that `request.user` is a AbstractBaseUser or
-    # AnonymousUser, but when I follow the code it looks like it's
-    # AbstractUser or AnonymousUser, which we *would* comply with
-    # here (BorrowdUser subclasses AbstractUser).
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     # Resolve against all items, including soft-deleted ones: an owner closing
     # their account soft-eletes their items, but the borrower may still need to
     # close out the stranded loan (RESOLVE_TRANSACTION). The guard below keeps
@@ -314,9 +310,8 @@ class ItemListView(
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         term = request.GET.get("search")
         if term is not None:
-            user: BorrowdUser = request.user  # type: ignore[assignment]
             SearchTerm.record_search(
-                user=user,
+                user=get_authenticated_user(request),
                 target=SearchTarget.ITEMS,
                 term=term,
             )

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -1,7 +1,6 @@
 from typing import Any
 from urllib.parse import urlencode
 
-from borrowd_users.request import get_authenticated_user
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
 from django.core.files.uploadedfile import UploadedFile
@@ -23,6 +22,7 @@ from borrowd_permissions.mixins import (
 )
 from borrowd_permissions.models import ItemOLP
 from borrowd_users.models import SearchTarget, SearchTerm
+from borrowd_users.request import get_authenticated_user
 
 from .card_helpers import (
     build_item_card_context,

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 from notifications.models import Notification
 
 from borrowd_users.models import BorrowdUser
+from borrowd_users.request import get_authenticated_user
 
 from .models import (
     ChannelType,
@@ -176,7 +177,7 @@ def _build_preferences_context(user: BorrowdUser) -> dict[str, Any]:
 
 @login_required
 def notification_preferences_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     context = _build_preferences_context(user)
     return render(request, "notifications/preferences.html", context)
 
@@ -184,7 +185,7 @@ def notification_preferences_view(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def toggle_preference(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     type_value = request.POST.get("notification_type", "")
     channel_value = request.POST.get("channel", "")
     enabled = request.POST.get("enabled") == "true"
@@ -220,7 +221,7 @@ def toggle_preference(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def bulk_toggle_preferences(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     scope = request.POST.get("scope", "")
     channel_value = request.POST.get("channel", "")
     enabled = request.POST.get("enabled") == "true"
@@ -276,7 +277,7 @@ def _format_notification(notification: Notification) -> str:
 
 @login_required
 def notification_inbox_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     # only show the notifications that where sent through the in-app channel
     qs: QuerySet[Notification] = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
@@ -316,7 +317,7 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     _app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
     return redirect("notification-inbox")
 
@@ -347,7 +348,7 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     visible_notifications = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     visible_notifications.update(unread=False)
     NotificationMetadata.objects.filter(

--- a/borrowd_users/tests/test_request_helpers.py
+++ b/borrowd_users/tests/test_request_helpers.py
@@ -1,0 +1,29 @@
+"""Tests for the request-scoped auth helpers in `borrowd_users.request`."""
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory, TestCase
+
+from borrowd_users.models import BorrowdUser
+from borrowd_users.request import get_authenticated_user
+
+
+class GetAuthenticatedUserTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    def test_returns_borrowd_user(self) -> None:
+        user = BorrowdUser.objects.create_user(
+            username="alice", email="alice@example.com", password="pw"
+        )
+        request = self.factory.get("/")
+        request.user = user
+
+        self.assertEqual(get_authenticated_user(request), user)
+
+    def test_raises_for_anonymous_user(self) -> None:
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        with self.assertRaises(PermissionDenied):
+            get_authenticated_user(request)

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -28,6 +28,7 @@ from borrowd_items.models import Item, ItemStatus, Transaction
 from .exceptions import AccountDeletionBlocked
 from .forms import ChangePasswordForm, CustomSignupForm, ProfileUpdateForm
 from .models import BorrowdUser, SearchTarget, SearchTerm
+from .request import get_authenticated_user
 from .services import soft_delete_account
 
 
@@ -74,7 +75,7 @@ def public_profile_view(
     if subject_user == request.user:
         return redirect("profile")
 
-    viewer: BorrowdUser = request.user  # type: ignore[assignment]
+    viewer = get_authenticated_user(request)
 
     # Check if the viewer shares a group with the subject user
     viewer_shares_group_with_subject = Membership.objects.filter(
@@ -97,13 +98,13 @@ def public_profile_view(
 
 @login_required
 def profile_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     profile = user.profile
 
     if request.method == "POST":
         form = ProfileUpdateForm(request.POST, request.FILES, instance=profile)
         if form.is_valid():
-            form.instance.updated_by = request.user  # type: ignore[assignment]
+            form.instance.updated_by = user
             form.save()
             messages.success(request, "Profile updated")
             return redirect("profile")
@@ -144,13 +145,13 @@ def delete_profile_photo_view(request: HttpRequest) -> JsonResponse:
     fields to be left as-is. This is also why it returns json rather than an http
     redirect or similar.
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     profile = user.profile
 
     if profile.image:
         profile.image.delete(save=False)
         profile.image = None
-        profile.updated_by = request.user  # type: ignore[assignment]
+        profile.updated_by = user
         profile.save()
         # Returns json rather than http in order to allow other in-progress fields to be left as-is.
         return JsonResponse(
@@ -182,7 +183,7 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     4. borrowed_items_from_others — items user is borrowing from others
     5. owned_items_available      — user's items with no active transactions
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     # All transactions associated with the user with status == REQUESTED (awaiting approval from someone)
     requested_transactions = Transaction.get_requested_status_transactions_for_user(
@@ -281,7 +282,7 @@ def delete_account_view(request: HttpRequest) -> HttpResponse:
 
     Requires the user to retype their username to delete their account
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     if request.POST.get("confirm_username", "").strip() != user.username:
         messages.error(
@@ -388,7 +389,7 @@ def search_terms_export_view(
     - target: optional, one of {"items", "groups"}
     - limit: optional, default 200, max 1000
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     if not user.is_staff:
         return HttpResponseForbidden("Admin access required.")
 


### PR DESCRIPTION
## Summary
Part of a series to fix the various mypy ignore issues we have.

This third PR removed the remaining `request.user # type: ignore` via `get_authenticated_user` (see `borrowd_users/request.py`), the helper added in #513. The helper narrows `request.user` from `AbstractBaseUser | AnonymousUser` to `BorrowdUser` and raises `PermissionDenied` if an anonymous user ever reaches a login-gated view. 
Next PR deals with untyped third parties.

## Linked Issue(s)
<!-- Closes #[issue number] -->
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- various files
  - route request.user through the helper.
- `borrowd_users/tests/test_request_helpers.py`
  -  Checks for user authenticated -> passes and user not authenticated -> raises

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. `uv run mypy . --strict`
2. `uv run manage.py test borrowd_users.tests.test_request_helpers`
3. `git grep -n "request.user.*# type: ignore" -- '*.py'` (are there leftover tpye ignores for request.user)

## Screenshots (if UI change)
<!-- Before / After if applicable -->
N/A -- no UI change.

## Checklist
- [X] I have tested this locally
- [X] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members
- [X] No debug logs, or unrelated changes included
- [ ] Migrations are included

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
N/A
