### PR TITLE
mypyp fixes: the final one

### DIFF
--- a/borrowd/adapters.py
+++ b/borrowd/adapters.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from allauth.account.adapter import DefaultAccountAdapter, HttpRequest
+from allauth.account.adapter import DefaultAccountAdapter
+from django.http import HttpRequest
 from ipware import get_client_ip
 
 
-class IPWareAccountAdapter(DefaultAccountAdapter):  # type: ignore[misc]
+class IPWareAccountAdapter(DefaultAccountAdapter):
     def get_client_ip(self, request: HttpRequest) -> Any:
         # ipware will automatically check common headers like X-Forwarded-For
         client_ip, is_routable = get_client_ip(request)

--- a/borrowd_beta/admin.py
+++ b/borrowd_beta/admin.py
@@ -7,7 +7,7 @@ from borrowd_users.request import get_authenticated_user
 from .models import BetaCode, BetaSignup
 
 
-class BetaCodeAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+class BetaCodeAdmin(admin.ModelAdmin[BetaCode]):
     readonly_fields = ["code", "created_by", "updated_by", "created_at", "updated_at"]
 
     def save_model(
@@ -26,7 +26,7 @@ class BetaCodeAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         obj.save()
 
 
-class BetaSignupAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+class BetaSignupAdmin(admin.ModelAdmin[BetaSignup]):
     # Make fields read-only
     readonly_fields = [field.name for field in BetaSignup._meta.fields]
 

--- a/borrowd_beta/views.py
+++ b/borrowd_beta/views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Literal
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -28,7 +29,9 @@ def signup(request: HttpRequest) -> HttpResponse:
 def set_cookie_response(request: HttpRequest, beta_signup: BetaSignup) -> HttpResponse:
     secure = getattr(settings, "BETA_SECURE_COOKIE", False)
     domain = getattr(settings, "BETA_COOKIE_DOMAIN", None)
-    samesite = getattr(settings, "BETA_COOKIE_SAMESITE", "Lax")
+    samesite: Literal["Lax", "Strict", "None", False] | None = getattr(
+        settings, "BETA_COOKIE_SAMESITE", "Lax"
+    )
     response = HttpResponse("Beta signup successful. Redirecting...")
     response["HX-Redirect"] = settings.BETA_SIGNUP_REDIRECT_PATH
     response.set_cookie(
@@ -37,7 +40,7 @@ def set_cookie_response(request: HttpRequest, beta_signup: BetaSignup) -> HttpRe
         secure=secure,
         domain=domain,
         httponly=True,
-        samesite=samesite,  # type: ignore[arg-type]
+        samesite=samesite,
         max_age=timedelta(days=90),
     )
     return response

--- a/borrowd_groups/filters.py
+++ b/borrowd_groups/filters.py
@@ -3,6 +3,8 @@ from typing import Any
 from django.db.models import Count, Q, QuerySet
 from django_filters import BooleanFilter, CharFilter, FilterSet
 
+from borrowd_users.request import get_authenticated_user
+
 from .models import Membership, MembershipStatus
 
 
@@ -48,7 +50,7 @@ class GroupFilter(FilterSet):  # type: ignore[misc]
             qs: QuerySet[Membership] = Membership.objects.select_related(
                 "group"
             ).filter(
-                user=self.request.user,
+                user=get_authenticated_user(self.request),
             )
             qs = qs.annotate(
                 active_members_count=Count(

--- a/borrowd_groups/filters.py
+++ b/borrowd_groups/filters.py
@@ -8,7 +8,8 @@ from borrowd_users.request import get_authenticated_user
 from .models import Membership, MembershipStatus
 
 
-# No typing for django_filter, so mypy doesn't like us subclassing.
+# django-filter is untyped (see the django_filters note in mypy.ini), so
+# subclassing it trips strict mode's "subclass of Any" check.
 class GroupFilter(FilterSet):  # type: ignore[misc]
     search = CharFilter(label="Search", method="filter_by_search")
     moderator_only = BooleanFilter(label="Moderator Only", method="filter_by_moderator")

--- a/borrowd_groups/forms.py
+++ b/borrowd_groups/forms.py
@@ -65,7 +65,7 @@ class BorrowdGroupForm(forms.ModelForm[BorrowdGroup]):
         }
 
     def clean_name(self) -> str:
-        name = self.cleaned_data.get("name")
+        name: str | None = self.cleaned_data.get("name")
 
         if not name:
             raise forms.ValidationError("Group name is required.")
@@ -82,7 +82,7 @@ class BorrowdGroupForm(forms.ModelForm[BorrowdGroup]):
         if queryset.exists():
             raise forms.ValidationError(DUPLICATE_GROUP_NAME_ERROR)
 
-        return name  # type: ignore[no-any-return]
+        return name
 
 
 class GroupCreateForm(BorrowdGroupForm):

--- a/borrowd_groups/migrations/0005_borrowdgroup_perms_group.py
+++ b/borrowd_groups/migrations/0005_borrowdgroup_perms_group.py
@@ -9,7 +9,7 @@ from django.db import migrations, models
 logger = getLogger("borrowd")
 
 
-def forwards_func(apps, schema_editor):  # type: ignore[no-untyped-def]
+def forwards_func(apps, schema_editor):
     BorrowdGroup = apps.get_model("borrowd_groups", "BorrowdGroup")
     for borrowd_group in BorrowdGroup.objects.all():
         try:
@@ -25,7 +25,7 @@ def forwards_func(apps, schema_editor):  # type: ignore[no-untyped-def]
             )
 
 
-def reverse_func(apps, schema_editor):  # type: ignore[no-untyped-def]
+def reverse_func(apps, schema_editor):
     pass
 
 

--- a/borrowd_groups/models.py
+++ b/borrowd_groups/models.py
@@ -295,6 +295,7 @@ class Membership(Model):
         null=False,
         blank=False,
     )
+    _previous_status: str | None = None
     status_changed_at = DateTimeField(
         null=True,
         blank=False,

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -219,7 +219,7 @@ class GroupCreateView(
 
     def get_form_kwargs(self) -> dict[str, Any]:
         kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.request.user
+        kwargs["user"] = get_authenticated_user(self.request)
         return kwargs
 
     def form_valid(self, form: GroupCreateForm) -> HttpResponse:
@@ -527,7 +527,7 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
 
         context["object_list"] = memberships
         context["has_groups"] = Membership.objects.filter(
-            user=self.request.user
+            user=get_authenticated_user(self.request)
         ).exists()
         return context
 
@@ -543,7 +543,7 @@ class GroupUpdateView(
 
     def get_form_kwargs(self) -> dict[str, Any]:
         kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.request.user
+        kwargs["user"] = get_authenticated_user(self.request)
         return kwargs
 
     def form_valid(self, form: GroupUpdateForm) -> HttpResponse:

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -490,7 +490,8 @@ def get_memberships_with_pending_actions(memberships: list[Membership]) -> set[i
     )
 
 
-# No typing for django_filter, so mypy doesn't like us subclassing.
+# django-filter is untyped (see the django_filters note in mypy.ini), so
+# subclassing FilterView trips strict mode's "subclass of Any" check.
 class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
     template_name = "groups/group_list.html"
     model = Membership
@@ -504,7 +505,10 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
                 target=SearchTarget.GROUPS,
                 term=term,
             )
-        return super().get(request, *args, **kwargs)  # type: ignore[no-any-return]
+        # super() is FilterView.get, which is Any (see the django_filters note
+        # in mypy.ini); annotating pins it to the real return type.
+        response: HttpResponse = super().get(request, *args, **kwargs)
+        return response
 
     def get_template_names(self) -> list[str]:
         if self.request.headers.get("HX-Request"):

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -457,7 +457,7 @@ class GroupJoinView(LoginRequiredMixin, View):
 
         # Check if membership_requires_approval, set pending
         membership = group.add_user(
-            request.user,  # type: ignore[arg-type]
+            get_authenticated_user(request),
             trust_level=form.cleaned_data["trust_level"],
         )
         if membership.status == MembershipStatus.PENDING:
@@ -499,9 +499,8 @@ class GroupListView(LoginRequiredMixin, FilterView):  # type: ignore[misc]
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         term = request.GET.get("search")
         if term is not None:
-            user: BorrowdUser = request.user  # type: ignore[assignment]
             SearchTerm.record_search(
-                user=user,
+                user=get_authenticated_user(request),
                 target=SearchTarget.GROUPS,
                 term=term,
             )
@@ -715,7 +714,7 @@ class LeaveGroupView(LoginRequiredMixin, View):
         self, request: HttpRequest, pk: int
     ) -> HttpResponsePermanentRedirect | HttpResponseRedirect:
         group = get_object_or_404(BorrowdGroup, pk=pk)
-        user: BorrowdUser = request.user  # type: ignore[assignment]
+        user = get_authenticated_user(request)
 
         membership = Membership.objects.filter(
             user=user,
@@ -763,7 +762,7 @@ class BecomeModeratorView(LoginRequiredMixin, View):
     def post(
         self, request: HttpRequest, pk: int
     ) -> HttpResponsePermanentRedirect | HttpResponseRedirect:
-        user: BorrowdUser = request.user  # type: ignore[assignment]
+        user = get_authenticated_user(request)
 
         with transaction.atomic():
             # Lock group row. This prevents race condition (two users clicking)

--- a/borrowd_items/filters.py
+++ b/borrowd_items/filters.py
@@ -10,7 +10,8 @@ from borrowd_users.request import get_authenticated_user
 from .models import Item, ItemCategory
 
 
-# No typing for django_filter, so mypy doesn't like us subclassing.
+# django-filter is untyped (see the django_filters note in mypy.ini), so
+# subclassing it trips strict mode's "subclass of Any" check.
 class ItemFilter(FilterSet):  # type: ignore[misc]
     search = CharFilter(label="Search", method="filter_by_search")
     categories = ModelMultipleChoiceFilter(

--- a/borrowd_items/filters.py
+++ b/borrowd_items/filters.py
@@ -5,6 +5,7 @@ from django_filters import CharFilter, FilterSet, ModelMultipleChoiceFilter
 from guardian.shortcuts import get_objects_for_user
 
 from borrowd_permissions.models import ItemOLP
+from borrowd_users.request import get_authenticated_user
 
 from .models import Item, ItemCategory
 
@@ -67,13 +68,13 @@ class ItemFilter(FilterSet):  # type: ignore[misc]
         if not hasattr(self, "_qs"):
             qs: QuerySet[Item] = (
                 get_objects_for_user(
-                    self.request.user,
+                    get_authenticated_user(self.request),
                     ItemOLP.VIEW,
                     klass=Item,
                     with_superuser=False,
                 )
                 .filter(deleted_at__isnull=True)
-                .exclude(owner=self.request.user)
+                .exclude(owner=get_authenticated_user(self.request))
             )
             if self.is_bound:
                 # ensure form validation before filtering

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -855,8 +855,9 @@ class Item(Model):
         from django.contrib.auth.models import Group
         from guardian.shortcuts import assign_perm, get_groups_with_perms, remove_perm
 
-        # guardian typing issue. will be fixed in a follow-up.
-        groups_that_can_view_item: QuerySet[Group] = get_groups_with_perms(self)  # type: ignore[assignment]
+        # guardian mis-types get_groups_with_perms as `Group | dict`; for the
+        # default attach_perms=False it returns a QuerySet[Group].
+        groups_that_can_view_item = cast("QuerySet[Group]", get_groups_with_perms(self))
         for group in groups_that_can_view_item:
             remove_perm(ItemOLP.VIEW, group, self)
 
@@ -1049,6 +1050,7 @@ class Transaction(Model):
         default=TransactionStatus.REQUESTED,
         help_text="The current status of the Transaction.",
     )
+    _previous_status: int | None = None
     resolution_reason = CharField(
         max_length=32,
         choices=ResolutionReason.choices,

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -20,7 +20,7 @@ from borrowd_permissions.mixins import (
     LoginOr404PermissionMixin,
 )
 from borrowd_permissions.models import ItemOLP
-from borrowd_users.models import BorrowdUser, SearchTarget, SearchTerm
+from borrowd_users.models import SearchTarget, SearchTerm
 from borrowd_users.request import get_authenticated_user
 
 from .card_helpers import (
@@ -234,7 +234,7 @@ class ItemDeleteView(
             )
             return redirect("item-detail", pk=item.pk)
 
-        user = cast(BorrowdUser, self.request.user)
+        user = get_authenticated_user(self.request)
 
         item.soft_delete(user)
         _add_message_safe(self.request, messages.SUCCESS, "Item deleted.")
@@ -251,7 +251,7 @@ class ItemDetailView(
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        user: BorrowdUser = self.request.user
+        user = get_authenticated_user(self.request)
 
         action_context = self.object.get_action_context_for(user=user)
 
@@ -323,7 +323,7 @@ class ItemListView(
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context_data(**kwargs)
-        user: BorrowdUser = self.request.user
+        user = get_authenticated_user(self.request)
 
         # Build card contexts for all items
         items = list(context["object_list"])
@@ -355,7 +355,7 @@ class ItemUpdateView(
         return context
 
     def form_valid(self, form: ItemForm) -> HttpResponse:
-        form.instance.updated_by = self.request.user
+        form.instance.updated_by = get_authenticated_user(self.request)
         response = super().form_valid(form)
         self._process_uploaded_photos()
         _add_message_safe(self.request, messages.SUCCESS, "Changes saved.")
@@ -368,6 +368,7 @@ class ItemUpdateView(
             return
 
         item: Item = self.object
+        user = get_authenticated_user(self.request)
         remaining_slots = 5 - item.photos.count()
 
         ext_validator = FileExtensionValidator(
@@ -385,8 +386,8 @@ class ItemUpdateView(
             ItemPhoto.objects.create(
                 item=item,
                 image=upload,
-                created_by=self.request.user,
-                updated_by=self.request.user,
+                created_by=user,
+                updated_by=user,
             )
 
         if skipped:
@@ -434,9 +435,10 @@ class ItemPhotoCreateView(
 
     def form_valid(self, form: ItemPhotoForm) -> HttpResponse:
         context = self.get_context_data()
+        user = get_authenticated_user(self.request)
         form.instance.item_id = context["item_pk"]
-        form.instance.created_by = self.request.user
-        form.instance.updated_by = self.request.user
+        form.instance.created_by = user
+        form.instance.updated_by = user
         return super().form_valid(form)
 
     def get_success_url(self) -> str:

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -447,7 +447,7 @@ class ItemPhotoCreateView(
         return super().form_valid(form)
 
     def get_success_url(self) -> str:
-        instance: ItemPhoto = self.object  # type: ignore[assignment]
+        instance: ItemPhoto | None = self.object
         if instance is None:
             return reverse("item-list")
 

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
 from django.core.validators import FileExtensionValidator
+from django.db.models import QuerySet
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -285,7 +286,8 @@ class ItemDetailView(
         return context
 
 
-# No typing for django_filter, so mypy doesn't like us subclassing.
+# django-filter is untyped (see the django_filters note in mypy.ini), so
+# subclassing FilterView trips strict mode's "subclass of Any" check.
 class ItemListView(
     LoginRequiredMixin,
     BorrowdTemplateFinderMixin,
@@ -315,10 +317,13 @@ class ItemListView(
                 target=SearchTarget.ITEMS,
                 term=term,
             )
-        return super().get(request, *args, **kwargs)  # type: ignore[no-any-return]
+        # super() is FilterView.get, which is Any (see the django_filters note
+        # in mypy.ini); annotating pins it to the real return type.
+        response: HttpResponse = super().get(request, *args, **kwargs)
+        return response
 
-    def get_queryset(self):  # type: ignore[no-untyped-def]
-        queryset = super().get_queryset()
+    def get_queryset(self) -> QuerySet[Item]:
+        queryset: QuerySet[Item] = super().get_queryset()
         return queryset.prefetch_related("photos")
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -114,11 +114,7 @@ def borrow_item(request: HttpRequest, pk: int) -> HttpResponse:
     if req_action is None:
         return HttpResponse("No action specified.", status=400)
 
-    # mypy complains that `request.user` is a AbstractBaseUser or
-    # AnonymousUser, but when I follow the code it looks like it's
-    # AbstractUser or AnonymousUser, which we *would* comply with
-    # here (BorrowdUser subclasses AbstractUser).
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     # Resolve against all items, including soft-deleted ones: an owner closing
     # their account soft-eletes their items, but the borrower may still need to
     # close out the stranded loan (RESOLVE_TRANSACTION). The guard below keeps
@@ -314,9 +310,8 @@ class ItemListView(
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         term = request.GET.get("search")
         if term is not None:
-            user: BorrowdUser = request.user  # type: ignore[assignment]
             SearchTerm.record_search(
-                user=user,
+                user=get_authenticated_user(request),
                 target=SearchTarget.ITEMS,
                 term=term,
             )

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -3,9 +3,8 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
-from django.core.validators import FileExtensionValidator
-from django.db.models import QuerySet
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models import QuerySet
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -423,7 +423,7 @@ class ItemPhotoCreateView(
     permission_required = ItemOLP.EDIT
     form_class = ItemPhotoForm
 
-    def get_permission_object(self):  # type: ignore[no-untyped-def]
+    def get_permission_object(self) -> Item:
         return get_object_or_404(Item, pk=self.kwargs["item_pk"])
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
@@ -464,7 +464,7 @@ class ItemPhotoDeleteView(
     permission_required = ItemOLP.EDIT
     http_method_names = ["post"]
 
-    def get_permission_object(self):  # type: ignore[no-untyped-def]
+    def get_permission_object(self) -> Item:
         return self.get_object().item
 
     def form_valid(self, form: ModelForm[ItemPhoto]) -> HttpResponse:

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -1,7 +1,6 @@
 from typing import Any
 from urllib.parse import urlencode
 
-from borrowd_users.request import get_authenticated_user
 from django.contrib import messages
 from django.contrib.messages.api import MessageFailure
 from django.core.files.uploadedfile import UploadedFile
@@ -23,6 +22,7 @@ from borrowd_permissions.mixins import (
 )
 from borrowd_permissions.models import ItemOLP
 from borrowd_users.models import SearchTarget, SearchTerm
+from borrowd_users.request import get_authenticated_user
 
 from .card_helpers import (
     build_item_card_context,

--- a/borrowd_notifications/signals.py
+++ b/borrowd_notifications/signals.py
@@ -89,13 +89,13 @@ def capture_transaction_previous_status(
     """Store the pre-save status on the instance so post_save can detect transitions."""
     if instance.pk:
         try:
-            instance._previous_status = Transaction.objects.values_list(  # type: ignore[attr-defined]
+            instance._previous_status = Transaction.objects.values_list(
                 "status", flat=True
             ).get(pk=instance.pk)
         except Transaction.DoesNotExist:
-            instance._previous_status = None  # type: ignore[attr-defined]
+            instance._previous_status = None
     else:
-        instance._previous_status = None  # type: ignore[attr-defined]
+        instance._previous_status = None
 
 
 @receiver(post_save, sender=Transaction)
@@ -241,13 +241,13 @@ def capture_membership_previous_status(
     """Store the pre-save status on the instance so post_save can detect transitions."""
     if instance.pk:
         try:
-            instance._previous_status = Membership.objects.values_list(  # type: ignore[attr-defined]
+            instance._previous_status = Membership.objects.values_list(
                 "status", flat=True
             ).get(pk=instance.pk)
         except Membership.DoesNotExist:
-            instance._previous_status = None  # type: ignore[attr-defined]
+            instance._previous_status = None
     else:
-        instance._previous_status = None  # type: ignore[attr-defined]
+        instance._previous_status = None
 
 
 @receiver(post_save, sender=Membership)

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.core import mail
-from django.http import HttpResponse
+from django.http import HttpResponseBase
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from notifications.models import Notification
@@ -1193,8 +1193,8 @@ class NotificationPreferenceToggleViewTests(TestCase):
 
     def _toggle(
         self, ntype: NotificationType, channel: str, enabled: bool
-    ) -> HttpResponse:
-        return self.client.post(  # type: ignore[return-value]
+    ) -> HttpResponseBase:
+        return self.client.post(
             "/settings/notifications/toggle/",
             {
                 "notification_type": ntype.value,
@@ -1203,8 +1203,8 @@ class NotificationPreferenceToggleViewTests(TestCase):
             },
         )
 
-    def _bulk_toggle(self, scope: str, channel: str, enabled: bool) -> HttpResponse:
-        return self.client.post(  # type: ignore[return-value]
+    def _bulk_toggle(self, scope: str, channel: str, enabled: bool) -> HttpResponseBase:
+        return self.client.post(
             "/settings/notifications/bulk-toggle/",
             {"scope": scope, "channel": channel, "enabled": str(enabled).lower()},
         )
@@ -1869,7 +1869,7 @@ class SummaryDigestTests(TestCase):
 
         call_count = 0
 
-        def fail_first(*args, **kwargs):  # type: ignore[no-untyped-def]
+        def fail_first(*args: object, **kwargs: object) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 from notifications.models import Notification
 
 from borrowd_users.models import BorrowdUser
+from borrowd_users.request import get_authenticated_user
 
 from .models import (
     ChannelType,
@@ -176,7 +177,7 @@ def _build_preferences_context(user: BorrowdUser) -> dict[str, Any]:
 
 @login_required
 def notification_preferences_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     context = _build_preferences_context(user)
     return render(request, "notifications/preferences.html", context)
 
@@ -184,7 +185,7 @@ def notification_preferences_view(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def toggle_preference(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     type_value = request.POST.get("notification_type", "")
     channel_value = request.POST.get("channel", "")
     enabled = request.POST.get("enabled") == "true"
@@ -220,7 +221,7 @@ def toggle_preference(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def bulk_toggle_preferences(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     scope = request.POST.get("scope", "")
     channel_value = request.POST.get("channel", "")
     enabled = request.POST.get("enabled") == "true"
@@ -276,7 +277,7 @@ def _format_notification(notification: Notification) -> str:
 
 @login_required
 def notification_inbox_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     # only show the notifications that where sent through the in-app channel
     qs: QuerySet[Notification] = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
@@ -316,7 +317,7 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     _app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
     return redirect("notification-inbox")
 
@@ -347,7 +348,7 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     visible_notifications = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     visible_notifications.update(unread=False)
     NotificationMetadata.objects.filter(

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -280,6 +280,7 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
 
     # only show the notifications that where sent through the in-app channel
+    # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     qs: QuerySet[Notification] = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     paginator = Paginator(qs, _INBOX_PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get("page", 1))
@@ -296,6 +297,7 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
         "notifications/inbox.html",
         {
             "page_obj": page_obj,
+            # notifications is untyped (see mypy.ini): unread() manager method is invisible.
             "unread_count": qs.unread().count(),  # type: ignore[attr-defined]
         },
     )
@@ -318,6 +320,7 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
 @require_POST
 def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
+    # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     _app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
     return redirect("notification-inbox")
 
@@ -349,6 +352,7 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 @require_POST
 def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
+    # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     visible_notifications = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     visible_notifications.update(unread=False)
     NotificationMetadata.objects.filter(

--- a/borrowd_permissions/mixins.py
+++ b/borrowd_permissions/mixins.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import PermissionDenied
-from django.http import Http404
+from django.db.models import Model
+from django.http import Http404, HttpRequest, HttpResponse
 from guardian.mixins import PermissionRequiredMixin
 
 
@@ -9,7 +10,9 @@ class LoginOr404PermissionMixin(PermissionRequiredMixin):
     Authenticated users without permission → 404
     """
 
-    def on_permission_check_fail(self, request, response, obj=None):  # type: ignore[no-untyped-def]
+    def on_permission_check_fail(
+        self, request: HttpRequest, response: HttpResponse, obj: Model | None = None
+    ) -> None:
         user = self.request.user
         if not user.is_authenticated:
             return super().on_permission_check_fail(request, response, obj)
@@ -22,7 +25,9 @@ class LoginOr403PermissionMixin(PermissionRequiredMixin):
     Authenticated users without permission → 403
     """
 
-    def on_permission_check_fail(self, request, response, obj=None):  # type: ignore[no-untyped-def]
+    def on_permission_check_fail(
+        self, request: HttpRequest, response: HttpResponse, obj: Model | None = None
+    ) -> None:
         user = self.request.user
         if not user.is_authenticated:
             return super().on_permission_check_fail(request, response, obj)

--- a/borrowd_users/adapters.py
+++ b/borrowd_users/adapters.py
@@ -4,7 +4,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.utils.crypto import get_random_string
 
 
-class BorrowdAccountAdapter(DefaultAccountAdapter):  # type: ignore[misc]
+class BorrowdAccountAdapter(DefaultAccountAdapter):
     """Project-owned allauth adapter for auth flow customizations."""
 
     def generate_login_code(self) -> str:

--- a/borrowd_users/forms.py
+++ b/borrowd_users/forms.py
@@ -234,7 +234,7 @@ class ProfileUpdateForm(forms.ModelForm[Profile]):
         return profile
 
 
-class ChangePasswordForm(SetPasswordForm):  # type: ignore[misc]
+class ChangePasswordForm(SetPasswordForm):
     """
     Custom password change form that doesn't require the old password.
 

--- a/borrowd_users/migrations/0003_alter_borrowduser_first_name_and_more.py
+++ b/borrowd_users/migrations/0003_alter_borrowduser_first_name_and_more.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 
 
-def forwards_func(apps, schema_editor):  # type: ignore[no-untyped-def]
+def forwards_func(apps, schema_editor):
     BorrowdUser = apps.get_model("borrowd_users", "BorrowdUser")
     for bu in BorrowdUser.objects.all():
         bu.first_name = bu.profile.first_name or "First"
@@ -11,7 +11,7 @@ def forwards_func(apps, schema_editor):  # type: ignore[no-untyped-def]
         bu.save()
 
 
-def reverse_func(apps, schema_editor):  # type: ignore[no-untyped-def]
+def reverse_func(apps, schema_editor):
     pass
 
 

--- a/borrowd_users/tests/test_request_helpers.py
+++ b/borrowd_users/tests/test_request_helpers.py
@@ -1,0 +1,29 @@
+"""Tests for the request-scoped auth helpers in `borrowd_users.request`."""
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory, TestCase
+
+from borrowd_users.models import BorrowdUser
+from borrowd_users.request import get_authenticated_user
+
+
+class GetAuthenticatedUserTests(TestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    def test_returns_borrowd_user(self) -> None:
+        user = BorrowdUser.objects.create_user(
+            username="alice", email="alice@example.com", password="pw"
+        )
+        request = self.factory.get("/")
+        request.user = user
+
+        self.assertEqual(get_authenticated_user(request), user)
+
+    def test_raises_for_anonymous_user(self) -> None:
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        with self.assertRaises(PermissionDenied):
+            get_authenticated_user(request)

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -349,7 +349,7 @@ class CustomSignupView(CreateView[BorrowdUser, CustomSignupForm]):
         return super().form_invalid(form)
 
 
-class CustomPasswordChangeView(PasswordChangeView):  # type: ignore[misc]
+class CustomPasswordChangeView(PasswordChangeView):
     """
     Custom password change view that displays validation errors as warning toasts.
 

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -28,6 +28,7 @@ from borrowd_items.models import Item, ItemStatus, Transaction
 from .exceptions import AccountDeletionBlocked
 from .forms import ChangePasswordForm, CustomSignupForm, ProfileUpdateForm
 from .models import BorrowdUser, SearchTarget, SearchTerm
+from .request import get_authenticated_user
 from .services import soft_delete_account
 
 
@@ -74,7 +75,7 @@ def public_profile_view(
     if subject_user == request.user:
         return redirect("profile")
 
-    viewer: BorrowdUser = request.user  # type: ignore[assignment]
+    viewer = get_authenticated_user(request)
 
     # Check if the viewer shares a group with the subject user
     viewer_shares_group_with_subject = Membership.objects.filter(
@@ -97,13 +98,13 @@ def public_profile_view(
 
 @login_required
 def profile_view(request: HttpRequest) -> HttpResponse:
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     profile = user.profile
 
     if request.method == "POST":
         form = ProfileUpdateForm(request.POST, request.FILES, instance=profile)
         if form.is_valid():
-            form.instance.updated_by = request.user  # type: ignore[assignment]
+            form.instance.updated_by = user
             form.save()
             messages.success(request, "Profile updated")
             return redirect("profile")
@@ -144,13 +145,13 @@ def delete_profile_photo_view(request: HttpRequest) -> JsonResponse:
     fields to be left as-is. This is also why it returns json rather than an http
     redirect or similar.
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     profile = user.profile
 
     if profile.image:
         profile.image.delete(save=False)
         profile.image = None
-        profile.updated_by = request.user  # type: ignore[assignment]
+        profile.updated_by = user
         profile.save()
         # Returns json rather than http in order to allow other in-progress fields to be left as-is.
         return JsonResponse(
@@ -182,7 +183,7 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     4. borrowed_items_from_others — items user is borrowing from others
     5. owned_items_available      — user's items with no active transactions
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     # All transactions associated with the user with status == REQUESTED (awaiting approval from someone)
     requested_transactions = Transaction.get_requested_status_transactions_for_user(
@@ -281,7 +282,7 @@ def delete_account_view(request: HttpRequest) -> HttpResponse:
 
     Requires the user to retype their username to delete their account
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
 
     if request.POST.get("confirm_username", "").strip() != user.username:
         messages.error(
@@ -388,7 +389,7 @@ def search_terms_export_view(
     - target: optional, one of {"items", "groups"}
     - limit: optional, default 200, max 1000
     """
-    user: BorrowdUser = request.user  # type: ignore[assignment]
+    user = get_authenticated_user(request)
     if not user.is_staff:
         return HttpResponseForbidden("Admin access required.")
 

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -374,7 +374,10 @@ class CustomPasswordChangeView(PasswordChangeView):
         if error_message:
             messages.warning(self.request, error_message)
 
-        return super().form_invalid(form)  # type: ignore[no-any-return]
+        # allauth's PasswordChangeView.form_invalid is loosely typed (returns
+        # Any); pin it to the real return type.
+        response: HttpResponse = super().form_invalid(form)
+        return response
 
 
 @login_required

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,6 +27,17 @@ follow_untyped_imports = true
 ignore_missing_imports = true
 
 [mypy-django_filters.*]
+# django-filter ships no type information, and unlike allauth its
+# source is essentially unannotated. Setting `follow_untyped_imports` surfaces a bunch
+# of new errors (untyped filter-field calls, missing re-exports, None-typed attrs, etc)
+# rather than fixing anything, so we keep the package typed as `Any` type.
+#
+# Consequence: every django-filter symbol is Any. Subclassing FilterSet /
+# FilterView trips strict mode's "subclass of Any" check
+# (see the remaining `type: ignore [misc]` in *_filters.py and the *ListView classes),
+# and calls to inherited methods like FilterView.get() / get_queryset() return `Any`.
+# Where we override those, the override annotates the real return type and assigns
+# the Any super() result to it, which keeps mypy happy.
 ignore_missing_imports = true
 
 [mypy-notifications.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,11 @@ plugins = mypy_django_plugin.main
 # accessors, managers), so model fields need no explicit annotations.
 django_settings_module = borrowd.config.dev.django
 
+[mypy-*.migrations.*]
+# Django-generated migrations include data functions with framework-typed
+# (apps, schema_editor) params that aren't worth annotating by hand.
+disallow_untyped_defs = false
+
 [mypy-allauth.*]
 ignore_missing_imports = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,7 +18,9 @@ django_settings_module = borrowd.config.dev.django
 disallow_untyped_defs = false
 
 [mypy-allauth.*]
-ignore_missing_imports = true
+# allauth ships no py.typed but carries inline annotations; follow them
+# instead of treating the package as Any (lets us subclass its views/adapters).
+follow_untyped_imports = true
 
 [mypy-environ]
 # No typing yet; see https://github.com/joke2k/django-environ/issues/365

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,6 +41,9 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 
 [mypy-notifications.*]
+# django-notifications-hq ships no type information, so (like django-filter) it
+# stays Any rather than surfacing noise. Consequence: BorrowdUser's reverse
+# accessor `user.notifications` and manager methods like `unread()` are invisible to mypy
 ignore_missing_imports = true
 
 [mypy-imagekit.*]

--- a/tests/test_borrowing_flows.py
+++ b/tests/test_borrowing_flows.py
@@ -189,7 +189,7 @@ class RejectedFlowTest(SimpleTestCase):
         self.assertEqual(self.item.status, ItemStatus.REQUESTED)
         ## Redirects to item detail page after processing action
         self.assertEqual(
-            response.url,  # type: ignore[attr-defined]
+            response["Location"],
             reverse("item-detail", kwargs={"pk": self.item.pk}),
         )
 


### PR DESCRIPTION
This is pointed at refactor/mypy-request-user. It should be changed to point at main after #517 is merged, or it should be merged into #517 first and then #517 gets merged to main.

## Summary
The last entry in a series to fix the various mypy ignore issues we have. With this, we have gone from over 130 type ignores to 10. Whoo!

This PR addresses untyped third parties, migration data functions, and assorted one-offs. The surviving issues can't be fixed at the moment for various reasons. There are comments explaining these reasons in the code.


## Linked Issue(s)
<!-- Closes #[issue number] -->
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor / cleanup
- [X] Configuration / infrastructure (mypy.ini)
- [ ] Documentation

## Changes Made
<!-- List the key files/components changed and why -->
- **migrations** (`mypy.ini`, two old data-migrations): 
  - added `mypy-*.migrations.*` [`disallow_untyped_defs = false`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_defs)
override. 
    - mypy's `--strict` flag (which we have on) turns on `disallow_untyped_defs` globally, which flags any function lacking type annotations, even in migrations. The two data migrations affected in this pr have unannotated `forwards_func(apps, schema_editor) / reverse_func(...)`, so strict mode errored on them (`no-untyped-def`). Setting `disallow_untyped_defs = false` turns the check off for migration files.
- **allauth** (`mypy.ini`, `borrowd/adapters.py`, `borrowd_users/{adapters,forms,views}.py`):
  - switched allauth from `ignore_missing_imports` to [`follow_untyped_imports`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-follow_untyped_imports). allauth ships no `py.typed` but is annotated, so following it makes the base classes have types.
- **guardian** (`borrowd_permissions/mixins.py`, `borrowd_items/{views,models}.py`):
  - annotated the mixin overrides (`on_permission_check_fail`, `get_permission_object`) to match guardian's real signatures, and replaced the `get_groups_with_perms` ignore with `cast(QuerySet[Group], ...)`. Guardian [does annotate the return `Union[Group, dict]`](https://github.com/django-guardian/django-guardian/blob/3.3.1/guardian/shortcuts.py#L445-L447), but the default `attach_perms=False` branch [returns `...objects.filter(...).distinct()`](https://github.com/django-guardian/django-guardian/blob/3.3.1/guardian/shortcuts.py#L501) (a `QuerySet`), so a cast is necessary to override the wrong default types.
- **django-filter** (`mypy.ini`, `*_filters.py`, `*ListView` in views): 
  - django-filter is unannotated, so no help there. Annotated the `FilterView.get()/get_queryset()` overrides and kept the 4 `FilterSet`/`FilterView` subclassing `misc` ignores, each pointing at the mypy.ini note.
- **django-notifications-hq** (`mypy.ini`, `borrowd_notifications/views.py`): 
  - django-notifications-hq is unannotated, so no help there. So `Notification` and its manager are `Any` and need explicit ignores.
- **notifications signals** (`borrowd_items/models.py`, `borrowd_groups/models.py`, `borrowd_notifications/signals.py`): 
  - declared `_previous_status` on the item and group instances for type consumption by `borrowd_notifications/signals.py`.
- `borrowd_beta/{admin,views}.py`, `borrowd_groups/forms.py`, `borrowd_users/views.py`, `borrowd_notifications/tests.py`, `tests/test_borrowing_flows.py`:
  - various one-off fixes


## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. `uv run mypy . --strict`
2. `uvx pre-commit run --all-files`
3. `uv run manage.py test`
4. `uv run manage.py makemigrations --check --dry-run`

## Screenshots (if UI change)
<!-- Before / After if applicable -->
N/A -- no UI change.

## Checklist
- [X] I have tested this locally
- [X] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members
- [X] No debug logs, or unrelated changes included
- [ ] Migrations are included

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
N/A