### PR TITLE
Feat/482/profile stats

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -1238,6 +1238,62 @@ class Transaction(Model):
             )
         )
 
+    @staticmethod
+    def get_successful_borrows(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Return the transactions in witch the user was a borrowers
+        and the item was successfuly RETURNED.
+        """
+
+        return Transaction.objects.filter(
+            Q(party2=user) & Q(status=TransactionStatus.RETURNED)
+        )
+
+    @staticmethod
+    def get_successful_lends(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Return the transactions in witch the user was a lender
+        and the item was successfuly RETURNED or has been Given away.
+        """
+
+        return Transaction.objects.filter(
+            Q(party1=user)
+            & Q(
+                status__in=[
+                    TransactionStatus.RETURNED,
+                    TransactionStatus.OWNERSHIP_TRANSFERRED,
+                ]
+            )
+        )
+
+    @staticmethod
+    def get_pending_return_requests(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns the transactions where the user is a borrower and the return has been requested.
+        We also include transactions where the Return is asserted but not yet confirmed.
+        """
+
+        return Transaction.objects.filter(
+            Q(party2=user)
+            & Q(
+                status__in=[
+                    TransactionStatus.RETURN_REQUESTED,
+                    TransactionStatus.RETURN_ASSERTED,
+                ]
+            )
+        )
+
+    @staticmethod
+    def get_past_disputes(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Returns the disputes involving the {user}, we filter on disputed_at instead if status
+        To track also disputes that will eventualy become resolved.
+        """
+
+        return Transaction.objects.filter(
+            Q(disputed_at__isnull=False) & (Q(party1=user) | Q(party2=user))
+        )
+
 
 class AvailabilitySubscriptionStatus(IntegerChoices):
     """

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -1261,6 +1261,21 @@ class Transaction(Model):
             & Q(
                 status__in=[
                     TransactionStatus.RETURNED,
+                ]
+            )
+        )
+
+    @staticmethod
+    def get_items_given_away(user: BorrowdUser) -> QuerySet["Transaction"]:
+        """
+        Return the transactions in witch the user was a lender
+        and the item was Given away.
+        """
+
+        return Transaction.objects.filter(
+            Q(party1=user)
+            & Q(
+                status__in=[
                     TransactionStatus.OWNERSHIP_TRANSFERRED,
                 ]
             )

--- a/borrowd_items/tests/test_transaction_query_helpers.py
+++ b/borrowd_items/tests/test_transaction_query_helpers.py
@@ -81,7 +81,7 @@ class TransactionQueryHelperTests(TestCase):
 
         self.assertQuerySetEqual(transactions, [matching_tx], ordered=False)
 
-    def test_get_successful_lends_returns_user_returned_and_transferred_lends(
+    def test_get_successful_lends_returns_user_returned_only(
         self,
     ) -> None:
         returned_tx = _transaction(
@@ -90,7 +90,7 @@ class TransactionQueryHelperTests(TestCase):
             self.borrower,
             TransactionStatus.RETURNED,
         )
-        transferred_tx = _transaction(
+        _transaction(
             _item(self.owner, "Given away saw"),
             self.owner,
             self.borrower,
@@ -119,7 +119,7 @@ class TransactionQueryHelperTests(TestCase):
 
         self.assertQuerySetEqual(
             transactions,
-            [returned_tx, transferred_tx],
+            [returned_tx],
             ordered=False,
         )
 

--- a/borrowd_items/tests/test_transaction_query_helpers.py
+++ b/borrowd_items/tests/test_transaction_query_helpers.py
@@ -1,0 +1,205 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from borrowd.models import TrustLevel
+from borrowd_items.models import Item, Transaction, TransactionStatus
+from borrowd_users.models import BorrowdUser
+
+
+def _user(username: str) -> BorrowdUser:
+    return BorrowdUser.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="password",
+    )
+
+
+def _item(owner: BorrowdUser, name: str) -> Item:
+    return Item.objects.create(
+        name=name,
+        description="Useful for testing",
+        owner=owner,
+        created_by=owner,
+        updated_by=owner,
+        trust_level_required=TrustLevel.STANDARD,
+    )
+
+
+def _transaction(
+    item: Item,
+    party1: BorrowdUser,
+    party2: BorrowdUser,
+    status: TransactionStatus,
+    **kwargs: object,
+) -> Transaction:
+    return Transaction.objects.create(
+        item=item,
+        party1=party1,
+        party2=party2,
+        status=status,
+        created_by=party1,
+        updated_by=party1,
+        **kwargs,
+    )
+
+
+class TransactionQueryHelperTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = _user("owner")
+        self.borrower = _user("borrower")
+        self.other_user = _user("other")
+
+    def test_get_successful_borrows_returns_user_returned_borrow_transactions(
+        self,
+    ) -> None:
+        matching_tx = _transaction(
+            _item(self.owner, "Returned drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.RETURNED,
+        )
+        _transaction(
+            _item(self.owner, "Collected drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.COLLECTED,
+        )
+        _transaction(
+            _item(self.borrower, "Returned saw"),
+            self.borrower,
+            self.owner,
+            TransactionStatus.RETURNED,
+        )
+        _transaction(
+            _item(self.owner, "Other returned drill"),
+            self.owner,
+            self.other_user,
+            TransactionStatus.RETURNED,
+        )
+
+        transactions = Transaction.get_successful_borrows(self.borrower)
+
+        self.assertQuerySetEqual(transactions, [matching_tx], ordered=False)
+
+    def test_get_successful_lends_returns_user_returned_and_transferred_lends(
+        self,
+    ) -> None:
+        returned_tx = _transaction(
+            _item(self.owner, "Returned drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.RETURNED,
+        )
+        transferred_tx = _transaction(
+            _item(self.owner, "Given away saw"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.OWNERSHIP_TRANSFERRED,
+        )
+        _transaction(
+            _item(self.owner, "Collected drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.COLLECTED,
+        )
+        _transaction(
+            _item(self.borrower, "Borrower lent item"),
+            self.borrower,
+            self.owner,
+            TransactionStatus.RETURNED,
+        )
+        _transaction(
+            _item(self.other_user, "Other lent item"),
+            self.other_user,
+            self.borrower,
+            TransactionStatus.RETURNED,
+        )
+
+        transactions = Transaction.get_successful_lends(self.owner)
+
+        self.assertQuerySetEqual(
+            transactions,
+            [returned_tx, transferred_tx],
+            ordered=False,
+        )
+
+    def test_get_pending_return_requests_returns_user_pending_return_borrows(
+        self,
+    ) -> None:
+        return_requested_tx = _transaction(
+            _item(self.owner, "Requested return drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.RETURN_REQUESTED,
+        )
+        return_asserted_tx = _transaction(
+            _item(self.owner, "Asserted return saw"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.RETURN_ASSERTED,
+        )
+        _transaction(
+            _item(self.owner, "Collected drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.COLLECTED,
+        )
+        _transaction(
+            _item(self.borrower, "Borrower requested return"),
+            self.borrower,
+            self.owner,
+            TransactionStatus.RETURN_REQUESTED,
+        )
+        _transaction(
+            _item(self.owner, "Other requested return"),
+            self.owner,
+            self.other_user,
+            TransactionStatus.RETURN_REQUESTED,
+        )
+
+        transactions = Transaction.get_pending_return_requests(self.borrower)
+
+        self.assertQuerySetEqual(
+            transactions,
+            [return_requested_tx, return_asserted_tx],
+            ordered=False,
+        )
+
+    def test_get_past_disputes_returns_disputed_transactions_for_either_party(
+        self,
+    ) -> None:
+        lender_dispute_tx = _transaction(
+            _item(self.owner, "Lender disputed drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.DISPUTED,
+            disputed_at=timezone.now(),
+        )
+        borrower_dispute_tx = _transaction(
+            _item(self.borrower, "Borrower disputed saw"),
+            self.borrower,
+            self.owner,
+            TransactionStatus.RETURNED,
+            disputed_at=timezone.now(),
+        )
+        _transaction(
+            _item(self.owner, "Resolved drill"),
+            self.owner,
+            self.borrower,
+            TransactionStatus.RESOLVED,
+        )
+        _transaction(
+            _item(self.other_user, "Other disputed item"),
+            self.other_user,
+            self.borrower,
+            TransactionStatus.DISPUTED,
+            disputed_at=timezone.now(),
+        )
+
+        transactions = Transaction.get_past_disputes(self.owner)
+
+        self.assertQuerySetEqual(
+            transactions,
+            [lender_dispute_tx, borrower_dispute_tx],
+            ordered=False,
+        )

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -4,6 +4,8 @@ from allauth.account.views import PasswordChangeView
 from django.contrib import messages
 from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required
+from django.db import DatabaseError
+from django.db.models.query import QuerySet
 from django.http import (
     Http404,
     HttpRequest,
@@ -32,6 +34,13 @@ from .request import get_authenticated_user
 from .services import soft_delete_account
 
 
+def safe_count(queryset: QuerySet[Any]) -> int | None:
+    try:
+        return queryset.count()
+    except DatabaseError:
+        return None
+
+
 def build_profile_context(
     subject_user: BorrowdUser,
     viewing_user: BorrowdUser,
@@ -46,12 +55,14 @@ def build_profile_context(
         "full_name": profile.full_name(),
         "bio": profile.bio,
         "profile_image_url": profile.image.url if profile.image else "",
-        "successful_borrows": Transaction.get_successful_borrows(subject_user).count(),
-        "successful_lends": Transaction.get_successful_lends(subject_user).count(),
-        "returns_requested": Transaction.get_pending_return_requests(
-            subject_user
-        ).count(),
-        "past_disputes": Transaction.get_past_disputes(subject_user).count(),
+        "successful_borrows": safe_count(
+            Transaction.get_successful_borrows(subject_user)
+        ),
+        "successful_lends": safe_count(Transaction.get_successful_lends(subject_user)),
+        "returns_requested": safe_count(
+            Transaction.get_pending_return_requests(subject_user)
+        ),
+        "past_disputes": safe_count(Transaction.get_past_disputes(subject_user)),
     }
 
     """

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 from allauth.account.views import PasswordChangeView
@@ -41,6 +42,16 @@ def safe_count(queryset: QuerySet[Any]) -> int | None:
         return None
 
 
+@dataclass(frozen=True)
+class ProfileStat:
+    value: int | None
+    description: str
+    text_class: str
+    icon: str
+    icon_class: str
+    icon_bg_class: str
+
+
 def build_profile_context(
     subject_user: BorrowdUser,
     viewing_user: BorrowdUser,
@@ -55,14 +66,49 @@ def build_profile_context(
         "full_name": profile.full_name(),
         "bio": profile.bio,
         "profile_image_url": profile.image.url if profile.image else "",
-        "successful_borrows": safe_count(
-            Transaction.get_successful_borrows(subject_user)
-        ),
-        "successful_lends": safe_count(Transaction.get_successful_lends(subject_user)),
-        "returns_requested": safe_count(
-            Transaction.get_pending_return_requests(subject_user)
-        ),
-        "past_disputes": safe_count(Transaction.get_past_disputes(subject_user)),
+        # Defined this way to make the html template less redondant
+        "profile_stats": [
+            ProfileStat(
+                value=safe_count(Transaction.get_successful_borrows(subject_user)),
+                description="Successful borrows",
+                text_class="text-success",
+                icon_bg_class="bg-success/10",
+                icon_class="w-4 h-4 text-success",
+                icon="check",
+            ),
+            ProfileStat(
+                value=safe_count(Transaction.get_successful_lends(subject_user)),
+                description="Successful lends",
+                text_class="text-success",
+                icon_bg_class="bg-success/10",
+                icon_class="w-4 h-4 text-success",
+                icon="check",
+            ),
+            ProfileStat(
+                value=safe_count(Transaction.get_items_given_away(subject_user)),
+                description="Items given away",
+                text_class="text-info",
+                icon_bg_class="bg-info/10",
+                icon_class="w-4 h-4 text-info",
+                icon="gift",
+            ),
+            ProfileStat(
+                value=safe_count(Transaction.get_pending_return_requests(subject_user)),
+                description="Item returns requested",
+                text_class="text-warning",
+                icon_bg_class="bg-warning/10",
+                icon_class="w-4 h-4 text-warning",
+                icon="arrow-path-rounded-square",
+            ),
+            ProfileStat(
+                value=safe_count(Transaction.get_past_disputes(subject_user)),
+                description="Past disputes",
+                text_class="text-error",
+                icon_bg_class="bg-error/10",
+                icon_class="w-4 h-4 text-error",
+                icon="exclamation-triangle",
+            ),
+        ],
     }
 
     """
@@ -140,13 +186,13 @@ def profile_view(request: HttpRequest) -> HttpResponse:
     else:
         form = ProfileUpdateForm(instance=profile)
 
-    profile_contex = build_profile_context(user, user)
-    profile_contex["form"] = form
+    profile_context = build_profile_context(user, user)
+    profile_context["form"] = form
 
     return render(
         request,
         "users/profile.html",
-        profile_contex,
+        profile_context,
     )
 
 

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -35,17 +35,23 @@ from .services import soft_delete_account
 def build_profile_context(
     subject_user: BorrowdUser,
     viewing_user: BorrowdUser,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """
     Profile context to determine which fields to display based on user roles
     """
     profile = subject_user.profile
 
     # Base profile context (all profile views get this).
-    profile_context: dict[str, str] = {
+    profile_context: dict[str, Any] = {
         "full_name": profile.full_name(),
         "bio": profile.bio,
         "profile_image_url": profile.image.url if profile.image else "",
+        "successful_borrows": Transaction.get_successful_borrows(subject_user).count(),
+        "successful_lends": Transaction.get_successful_lends(subject_user).count(),
+        "returns_requested": Transaction.get_pending_return_requests(
+            subject_user
+        ).count(),
+        "past_disputes": Transaction.get_past_disputes(subject_user).count(),
     }
 
     """
@@ -60,6 +66,18 @@ def build_profile_context(
     """
     if viewing_user == subject_user:
         profile_context["email"] = subject_user.email
+        profile_context["profile"] = profile
+
+        # Drives the delete-account modal. Borrowing blocks deletion; items still
+        # out on loan nudge the user to retrieve them first; owning only idle items
+        # just warns they'll be removed; with nothing at all it's a plain confirm.
+        profile_context["is_borrowing"] = Transaction.get_active_borrows_for_user(
+            subject_user
+        ).exists()
+        profile_context["is_lending"] = Transaction.get_active_lends_for_user(
+            subject_user
+        ).exists()
+        profile_context["has_items"] = Item.objects.filter(owner=subject_user).exists()
 
     return profile_context
 
@@ -111,23 +129,13 @@ def profile_view(request: HttpRequest) -> HttpResponse:
     else:
         form = ProfileUpdateForm(instance=profile)
 
-    # Drives the delete-account modal. Borrowing blocks deletion; items still
-    # out on loan nudge the user to retrieve them first; owning only idle items
-    # just warns they'll be removed; with nothing at all it's a plain confirm.
-    is_borrowing = Transaction.get_active_borrows_for_user(user).exists()
-    is_lending = Transaction.get_active_lends_for_user(user).exists()
-    has_items = Item.objects.filter(owner=user).exists()
+    profile_contex = build_profile_context(user, user)
+    profile_contex["form"] = form
 
     return render(
         request,
         "users/profile.html",
-        {
-            "profile": profile,
-            "form": form,
-            "is_borrowing": is_borrowing,
-            "is_lending": is_lending,
-            "has_items": has_items,
-        },
+        profile_contex,
     )
 
 

--- a/templates/components/profile/nav_row.html
+++ b/templates/components/profile/nav_row.html
@@ -3,6 +3,7 @@
 <c-vars href="#" label="" />
 
 <a href="{{ href }}"
+   {{ attrs }}
    class="card bg-primary-content border border-gray-200 shadow-sm rounded-md flex flex-row items-center justify-between px-4 py-3 hover:bg-base-200 transition-colors">
     <span class="text-sm  text-base-content font-normal">{{ label }}</span>
 

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -8,98 +8,191 @@
 {% endblock %}
 
 {% block content %}
-    <div class="flex flex-col w-full max-w-2xl mx-auto px-4 py-4 gap-6">
+    <div x-data="{ openDrawer: null }"
+         class="flex flex-col w-full max-w-2xl mx-auto px-4 py-4 gap-6">
 
         {% include "components/page_header.html" with title=_("Profile") %}
 
         {# ── Personal Information ──────────────────────────────────────── #}
         <section class="flex flex-col gap-2">
-            <p class="text-xs font-semibold text-base-content px-1">
-                {% trans "Personal information" %}
-            </p>
-
             <form method="post"
                   enctype="multipart/form-data"
-                  class="card bg-primary-content rounded-md border border-gray-200 shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] p-4 flex flex-col gap-4"
+                  class="flex flex-col gap-4"
                   onsubmit="this.querySelector('button[type=submit]').disabled = true;">
                 {% csrf_token %}
 
                 {# Avatar row #}
-                <div class="flex items-center justify-between">
-                    <div class="avatar relative">
-                        <div class="w-16 rounded-full ring-2 ring-base-100">
-                            <img src="{% if profile.image %}{{ profile.image.url }}{% else %}https://ui-avatars.com/api/?name={{ profile.full_name|urlencode }}&background=random{% endif %}"
-                                 alt="{% trans 'Profile photo' %}"
-                                 id="avatar-preview"
-                                 onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='inline-flex';" />
-                            <span style="display: none"
-                                  class="items-center justify-center w-16 h-16 rounded-full bg-base-200 text-base-content/40">
-                                {% heroicon_outline "user-circle" class="w-2/3 h-2/3" %}
-                            </span>
+                <div class="flex flex-col gap-2">
+                    <p class="text-xs font-semibold text-base-content px-1">
+                        {% trans "Avatar" %}
+                    </p>
+                    <div class="bg-primary-content rounded-md border border-gray-200 shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] flex items-center justify-between p-4">
+                        <div class="avatar relative">
+                            <div class="w-16 rounded-full ring-2 ring-base-100">
+                                <img src="{% if profile.image %}{{ profile.image.url }}{% else %}https://ui-avatars.com/api/?name={{ profile.full_name|urlencode }}&background=random{% endif %}"
+                                     alt="{% trans 'Profile photo' %}"
+                                     id="avatar-preview"
+                                     onerror="this.onerror=null; this.style.display='none'; this.nextElementSibling.style.display='inline-flex';" />
+                                <span style="display: none"
+                                      class="items-center justify-center w-16 h-16 rounded-full bg-base-200 text-base-content/40">
+                                    {% heroicon_outline "user-circle" class="w-2/3 h-2/3" %}
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3">
+                            <label for="id_image"
+                                   class="btn btn-sm bg-base-200 border border-base-300 rounded-sm cursor-pointer">
+                                {% heroicon_mini "pencil" class="size-4" %}
+                                {% trans "Edit" %}
+                            </label>
+
+                            <button type="button"
+                                    onclick="openDeleteModal()"
+                                    id="delete-avatar-btn"
+                                    class="btn btn-sm btn-error btn-soft rounded-sm"
+                                    {% if not profile.image %}disabled{% endif %}>
+                                {% heroicon_mini "trash" class="size-3" %}
+                                {% trans "Delete" %}
+                            </button>
+                        </div>
+
+                        {# Hidden file input rendered by the form widget #}
+                        {{ form.image }}
+                    </div>
+                </div>
+
+                {# Personal fields #}
+                <details class="card bg-primary-content transition-colors"
+                         :class="openDrawer === 'info' ? 'rounded-md border border-gray-200 shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] p-4 flex flex-col gap-2 ' : 'border border-gray-200 shadow-sm rounded-md flex flex-row items-center justify-between px-4 py-3 hover:bg-base-200'">
+                    <summary class="w-full flex flex-row items-center justify-between cursor-pointer "
+                             @click="openDrawer = openDrawer === 'info' ? null : 'info'">
+                        <span class="text-base-content px-1"
+                              :class="openDrawer === 'info' ? 'text-xs font-semibold' : 'text-sm '">
+                            {% trans "Personal information" %}
+                        </span>
+                        <div class="bg-base-200 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0 transition-transform duration-200 ease-out"
+                             :class="openDrawer === 'info' ? 'rotate-90' : 'rotate-0'">
+                            {% heroicon_micro "plus" class="w-4 h-4 text-base-content/60 opacity-60" %}
+                        </div>
+                    </summary>
+
+                    <div x-show="openDrawer === 'info'"
+                         x-collapse
+                         class="border-t border-base-300">
+                        <c-form.field label="First name"
+                                      name="{{ form.first_name.html_name }}"
+                                      id="{{ form.first_name.id_for_label }}"
+                                      type="text"
+                                      value="{{ form.first_name.value }}"
+                                      errors="{{ form.first_name.errors.0 }}" />
+
+                        <c-form.field label="Last name"
+                                      name="{{ form.last_name.html_name }}"
+                                      id="{{ form.last_name.id_for_label }}"
+                                      type="text"
+                                      value="{{ form.last_name.value }}"
+                                      errors="{{ form.last_name.errors.0 }}" />
+
+                        <c-form.field label="Email"
+                                      name="{{ form.email.html_name }}"
+                                      id="{{ form.email.id_for_label }}"
+                                      type="email"
+                                      value="{{ form.email.value }}"
+                                      autocomplete="email"
+                                      errors="{{ form.email.errors.0 }}" />
+
+                        <c-form.textarea label="About yourself"
+                                         name="{{ form.bio.html_name }}"
+                                         id="{{ form.bio.id_for_label }}"
+                                         value="{{ form.bio.value|default:'' }}"
+                                         placeholder="Tell others a bit about yourself"
+                                         max_length="200"
+                                         rows="4"
+                                         errors="{{ form.bio.errors.0 }}" />
+
+                        <div class="flex justify-end pt-1">
+                            <button type="submit" class="btn btn-primary rounded-md">
+                                {% trans "Update profile" %}
+                            </button>
                         </div>
                     </div>
 
-                    <div class="flex items-center gap-3">
-                        <label for="id_image"
-                               class="btn btn-sm bg-base-200 border border-base-300 rounded-sm cursor-pointer">
-                            {% heroicon_mini "pencil" class="size-4" %}
-                            {% trans "Edit" %}
-                        </label>
-
-                        <button type="button"
-                                onclick="openDeleteModal()"
-                                id="delete-avatar-btn"
-                                class="btn btn-sm btn-error btn-soft rounded-sm"
-                                {% if not profile.image %}disabled{% endif %}>
-                            {% heroicon_mini "trash" class="size-3" %}
-                            {% trans "Delete" %}
-                        </button>
-                    </div>
-
-                    {# Hidden file input rendered by the form widget #}
-                    {{ form.image }}
-                </div>
-
-                <c-divider class="my-0" />
-
-                {# Personal fields #}
-                <c-form.field label="First name"
-                              name="{{ form.first_name.html_name }}"
-                              id="{{ form.first_name.id_for_label }}"
-                              type="text"
-                              value="{{ form.first_name.value }}"
-                              errors="{{ form.first_name.errors.0 }}" />
-
-                <c-form.field label="Last name"
-                              name="{{ form.last_name.html_name }}"
-                              id="{{ form.last_name.id_for_label }}"
-                              type="text"
-                              value="{{ form.last_name.value }}"
-                              errors="{{ form.last_name.errors.0 }}" />
-
-                <c-form.field label="Email"
-                              name="{{ form.email.html_name }}"
-                              id="{{ form.email.id_for_label }}"
-                              type="email"
-                              value="{{ form.email.value }}"
-                              autocomplete="email"
-                              errors="{{ form.email.errors.0 }}" />
-
-                <c-form.textarea label="About yourself"
-                                 name="{{ form.bio.html_name }}"
-                                 id="{{ form.bio.id_for_label }}"
-                                 value="{{ form.bio.value|default:'' }}"
-                                 placeholder="Tell others a bit about yourself"
-                                 max_length="200"
-                                 rows="4"
-                                 errors="{{ form.bio.errors.0 }}" />
-
-                <div class="flex justify-end pt-1">
-                    <button type="submit" class="btn btn-primary rounded-md">
-                        {% trans "Update profile" %}
-                    </button>
-                </div>
+                </details>
             </form>
+        </section>
+
+        {# ── Profile Stats ───────────────────────────────────────────────────────── #}
+        <section class="flex flex-col gap-2">
+            <p class="text-xs font-semibold text-base-content px-1">
+                {% trans "Stats" %}
+            </p>
+
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-2xl font-semibold leading-none text-success">
+                                {{ successful_borrows }}
+                            </p>
+                            <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                {% trans "Successful borrows" %}
+                            </p>
+                        </div>
+                        <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                            {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-2xl font-semibold leading-none text-success">
+                                {{ successful_lends }}
+                            </p>
+                            <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                {% trans "Successful lends" %}
+                            </p>
+                        </div>
+                        <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                            {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-2xl font-semibold leading-none text-warning">
+                                {{ returns_requested }}
+                            </p>
+                            <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                {% trans "Item returns requested" %}
+                            </p>
+                        </div>
+                        <div class="bg-warning/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                            {% heroicon_micro "arrow-path-rounded-square" class="w-4 h-4 text-warning" %}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-2xl font-semibold leading-none text-error">
+                                {{ past_disputes }}
+                            </p>
+                            <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                {% trans "Past disputes" %}
+                            </p>
+                        </div>
+                        <div class="bg-error/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                            {% heroicon_micro "exclamation-triangle" class="w-4 h-4 text-error" %}
+                        </div>
+                    </div>
+                </div>
+            </div>
         </section>
 
         {# ── Security ──────────────────────────────────────────────────── #}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -129,236 +129,189 @@
             </p>
 
             <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <p class="text-2xl font-semibold leading-none text-success">
-                                {{ successful_borrows|default:"--" }}
-                            </p>
-                            <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                {% trans "Successful borrows" %}
-                            </p>
-                        </div>
-                        <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                            {% heroicon_micro "check" class="w-4 h-4 text-success" %}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <p class="text-2xl font-semibold leading-none text-success">
-                                {{ successful_lends|default:"--" }}
-                            </p>
-                            <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                {% trans "Successful lends" %}
-                            </p>
-                        </div>
-                        <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                            {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                {% for stat in profile_stats %}
+                    <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="text-2xl font-semibold leading-none {{ stat.text_class }}">
+                                    {{ stat.value|default_if_none:"--" }}
+                                </p>
+                                <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                    {% trans stat.description %}
+                                </p>
+                            </div>
+                            <div class="{{ stat.icon_bg_class }} shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                {% heroicon_micro stat.icon class=stat.icon_class %}
+                            </div>
                         </div>
                     </div>
+                {% endfor %}
+            </section>
+
+            {# ── Security ──────────────────────────────────────────────────── #}
+            <section class="flex flex-col gap-2 ">
+                <p class="text-xs font-semibold text-base-content px-1">
+                    {% trans "Security" %}
+                </p>
+
+                {% url 'account_change_password' as change_password_url %}
+                {% if change_password_url %}
+                    <c-profile.nav-row href="{{ change_password_url }}" label="Change password" />
+                {% endif %}
+            </section>
+
+            {# ── Notifications ─────────────────────────────────────────────── #}
+            <section class="flex flex-col gap-2">
+                <p class="text-xs font-semibold text-base-content px-1">
+                    {% trans "Notifications" %}
+                </p>
+                <c-profile.nav-row href="{% url 'notification-preferences' %}"
+                                   label="Notification settings" />
+            </section>
+
+            {# ── Account ───────────────────────────────────────────────────── #}
+            <section class="flex flex-col gap-2">
+                <p class="text-xs font-semibold text-base-content px-1">
+                    {% trans "Account" %}
+                </p>
+
+                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md flex flex-row items-center justify-between px-4 py-3">
+                    <span class="text-sm font-medium text-base-content">{% trans "Delete account" %}</span>
+                    <button type="button"
+                            onclick="openDeleteAccountModal()"
+                            class="btn btn-soft btn-error font-semibold rounded-sm">
+                        {% heroicon_mini "trash" class="size-3" %}
+                        {% trans "Delete" %}
+                    </button>
                 </div>
+            </section>
 
-                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <p class="text-2xl font-semibold leading-none text-warning">
-                                {{ returns_requested|default:"--" }}
-                            </p>
-                            <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                {% trans "Item returns requested" %}
-                            </p>
-                        </div>
-                        <div class="bg-warning/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                            {% heroicon_micro "arrow-path-rounded-square" class="w-4 h-4 text-warning" %}
-                        </div>
-                    </div>
-                </div>
+        </div>
 
-                <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <p class="text-2xl font-semibold leading-none text-error">
-                                {{ past_disputes|default:"--" }}
-                            </p>
-                            <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                {% trans "Past disputes" %}
-                            </p>
-                        </div>
-                        <div class="bg-error/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                            {% heroicon_micro "exclamation-triangle" class="w-4 h-4 text-error" %}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        {# ── Security ──────────────────────────────────────────────────── #}
-        <section class="flex flex-col gap-2 ">
-            <p class="text-xs font-semibold text-base-content px-1">
-                {% trans "Security" %}
-            </p>
-
-            {% url 'account_change_password' as change_password_url %}
-            {% if change_password_url %}
-                <c-profile.nav-row href="{{ change_password_url }}" label="Change password" />
-            {% endif %}
-        </section>
-
-        {# ── Notifications ─────────────────────────────────────────────── #}
-        <section class="flex flex-col gap-2">
-            <p class="text-xs font-semibold text-base-content px-1">
-                {% trans "Notifications" %}
-            </p>
-            <c-profile.nav-row href="{% url 'notification-preferences' %}"
-                               label="Notification settings" />
-        </section>
-
-        {# ── Account ───────────────────────────────────────────────────── #}
-        <section class="flex flex-col gap-2">
-            <p class="text-xs font-semibold text-base-content px-1">
-                {% trans "Account" %}
-            </p>
-
-            <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md flex flex-row items-center justify-between px-4 py-3">
-                <span class="text-sm font-medium text-base-content">{% trans "Delete account" %}</span>
-                <button type="button"
-                        onclick="openDeleteAccountModal()"
-                        class="btn btn-soft btn-error font-semibold rounded-sm">
-                    {% heroicon_mini "trash" class="size-3" %}
-                    {% trans "Delete" %}
-                </button>
-            </div>
-        </section>
-
-    </div>
-
-    {# ── Delete profile picture confirmation modal ────────────────── #}
-    <dialog id="delete-avatar-modal" class="modal modal-bottom sm:modal-middle">
-        <div class="modal-box rounded-t-2xl sm:rounded-2xl p-6 max-w-lg max-h-[70rem]">
-            <form method="dialog">
-                <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
-                    {% heroicon_mini "x-mark" class="w-3 h-3" %}
-                </button>
-            </form>
-
-            <h3 class="text-xl font-bold leading-7 p-5">
-                {% trans "Are you sure you want to delete your profile picture?" %}
-            </h3>
-            <p class="px-5 py-2 leading-7 text-xl">
-                {% trans "We advise everyone to have a profile picture so they can identify each other." %}
-            </p>
-
-            <div class="modal-action justify-end pt-6 gap-3">
+        {# ── Delete profile picture confirmation modal ────────────────── #}
+        <dialog id="delete-avatar-modal" class="modal modal-bottom sm:modal-middle">
+            <div class="modal-box rounded-t-2xl sm:rounded-2xl p-6 max-w-lg max-h-[70rem]">
                 <form method="dialog">
-                    <button class="btn btn-ghost font-semibold">
-                        {% trans "No, cancel" %}
+                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+                        {% heroicon_mini "x-mark" class="w-3 h-3" %}
                     </button>
                 </form>
-                <button type="button"
-                        onclick="confirmDeleteAvatar()"
-                        class="btn btn-soft btn-error font-semibold">
-                    {% trans "Yes, delete" %}
-                </button>
-            </div>
-        </div>
-        <form method="dialog" class="modal-backdrop">
-            <button>
-                close
-            </button>
-        </form>
-    </dialog>
 
-    {# ── Delete account confirmation modal ────────────────── #}
-    <dialog id="delete-account-modal" class="modal modal-bottom sm:modal-middle">
-        <div class="modal-box rounded-t-2xl sm:rounded-2xl p-6 max-w-lg max-h-[70rem]">
-            <form method="dialog">
-                <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
-                    {% heroicon_mini "x-mark" class="w-3 h-3" %}
-                </button>
-            </form>
-
-            {% if is_borrowing %}
-                {# ── Borrowing: deletion blocked ────────────────── #}
                 <h3 class="text-xl font-bold leading-7 p-5">
-                    {% trans "You currently have pending transactions" %}
+                    {% trans "Are you sure you want to delete your profile picture?" %}
                 </h3>
                 <p class="px-5 py-2 leading-7 text-xl">
-                    {% trans "To delete your profile, you'll need to return the items you've borrowed or cancel any pending transactions. Once the owner confirms the return, you'll be able to delete your profile." %}
+                    {% trans "We advise everyone to have a profile picture so they can identify each other." %}
                 </p>
-                <div class="modal-action justify-end pt-6">
+
+                <div class="modal-action justify-end pt-6 gap-3">
                     <form method="dialog">
                         <button class="btn btn-ghost font-semibold">
-                            {% trans "Close" %}
+                            {% trans "No, cancel" %}
                         </button>
                     </form>
+                    <button type="button"
+                            onclick="confirmDeleteAvatar()"
+                            class="btn btn-soft btn-error font-semibold">
+                        {% trans "Yes, delete" %}
+                    </button>
                 </div>
-            {% else %}
-                {% if is_lending %}
-                    {# Items out on loan: nudge to retrieve, but allow #}
+            </div>
+            <form method="dialog" class="modal-backdrop">
+                <button>
+                    close
+                </button>
+            </form>
+        </dialog>
+
+        {# ── Delete account confirmation modal ────────────────── #}
+        <dialog id="delete-account-modal" class="modal modal-bottom sm:modal-middle">
+            <div class="modal-box rounded-t-2xl sm:rounded-2xl p-6 max-w-lg max-h-[70rem]">
+                <form method="dialog">
+                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+                        {% heroicon_mini "x-mark" class="w-3 h-3" %}
+                    </button>
+                </form>
+
+                {% if is_borrowing %}
+                    {# ── Borrowing: deletion blocked ────────────────── #}
                     <h3 class="text-xl font-bold leading-7 p-5">
-                        {% trans "You're still lending items" %}
+                        {% trans "You currently have pending transactions" %}
                     </h3>
                     <p class="px-5 py-2 leading-7 text-xl">
-                        {% trans "If you delete your profile, your listed items will also be removed. We recommend retrieving your items before deleting your profile." %}
+                        {% trans "To delete your profile, you'll need to return the items you've borrowed or cancel any pending transactions. Once the owner confirms the return, you'll be able to delete your profile." %}
                     </p>
-                {% elif has_items %}
-                    {# Owns only idle items: warn they'll be removed, but allow #}
-                    <h3 class="text-xl font-bold leading-7 p-5">
-                        {% trans "Your listed items will be removed" %}
-                    </h3>
-                    <p class="px-5 py-2 leading-7 text-xl">
-                        {% trans "If you delete your profile, the items you've listed on Borrow'd will be removed too." %}
-                    </p>
+                    <div class="modal-action justify-end pt-6">
+                        <form method="dialog">
+                            <button class="btn btn-ghost font-semibold">
+                                {% trans "Close" %}
+                            </button>
+                        </form>
+                    </div>
                 {% else %}
-                    <h3 class="text-xl font-bold leading-7 p-5">
-                        {% trans "Are you sure you want to delete your profile?" %}
-                    </h3>
+                    {% if is_lending %}
+                        {# Items out on loan: nudge to retrieve, but allow #}
+                        <h3 class="text-xl font-bold leading-7 p-5">
+                            {% trans "You're still lending items" %}
+                        </h3>
+                        <p class="px-5 py-2 leading-7 text-xl">
+                            {% trans "If you delete your profile, your listed items will also be removed. We recommend retrieving your items before deleting your profile." %}
+                        </p>
+                    {% elif has_items %}
+                        {# Owns only idle items: warn they'll be removed, but allow #}
+                        <h3 class="text-xl font-bold leading-7 p-5">
+                            {% trans "Your listed items will be removed" %}
+                        </h3>
+                        <p class="px-5 py-2 leading-7 text-xl">
+                            {% trans "If you delete your profile, the items you've listed on Borrow'd will be removed too." %}
+                        </p>
+                    {% else %}
+                        <h3 class="text-xl font-bold leading-7 p-5">
+                            {% trans "Are you sure you want to delete your profile?" %}
+                        </h3>
+                    {% endif %}
+
+                    <form method="post" action="{% url 'account-delete' %}" class="px-5">
+                        {% csrf_token %}
+                        <label for="confirm-username" class="block text-sm font-medium pb-1">
+                            {% blocktrans with username=profile.user.username %}To confirm, type {{ username }} below{% endblocktrans %}
+                        </label>
+                        <input type="text"
+                               id="confirm-username"
+                               name="confirm_username"
+                               autocomplete="off"
+                               autocapitalize="off"
+                               spellcheck="false"
+                               data-expected-username="{{ profile.user.username }}"
+                               oninput="syncDeleteAccountButton(this)"
+                               class="input input-bordered w-full" />
+
+                        <div class="modal-action justify-end pt-6 gap-3">
+                            <button type="button"
+                                    onclick="document.getElementById('delete-account-modal').close()"
+                                    class="btn btn-ghost font-semibold">
+                                {% trans "Cancel" %}
+                            </button>
+                            <button type="submit"
+                                    id="delete-account-submit"
+                                    class="btn btn-soft btn-error font-semibold"
+                                    disabled>
+                                {% heroicon_mini "trash" class="size-3" %}
+                                {% trans "Delete" %}
+                            </button>
+                        </div>
+                    </form>
                 {% endif %}
 
-                <form method="post" action="{% url 'account-delete' %}" class="px-5">
-                    {% csrf_token %}
-                    <label for="confirm-username" class="block text-sm font-medium pb-1">
-                        {% blocktrans with username=profile.user.username %}To confirm, type {{ username }} below{% endblocktrans %}
-                    </label>
-                    <input type="text"
-                           id="confirm-username"
-                           name="confirm_username"
-                           autocomplete="off"
-                           autocapitalize="off"
-                           spellcheck="false"
-                           data-expected-username="{{ profile.user.username }}"
-                           oninput="syncDeleteAccountButton(this)"
-                           class="input input-bordered w-full" />
+            </div>
+            <form method="dialog" class="modal-backdrop">
+                <button>
+                    close
+                </button>
+            </form>
+        </dialog>
 
-                    <div class="modal-action justify-end pt-6 gap-3">
-                        <button type="button"
-                                onclick="document.getElementById('delete-account-modal').close()"
-                                class="btn btn-ghost font-semibold">
-                            {% trans "Cancel" %}
-                        </button>
-                        <button type="submit"
-                                id="delete-account-submit"
-                                class="btn btn-soft btn-error font-semibold"
-                                disabled>
-                            {% heroicon_mini "trash" class="size-3" %}
-                            {% trans "Delete" %}
-                        </button>
-                    </div>
-                </form>
-            {% endif %}
-
-        </div>
-        <form method="dialog" class="modal-backdrop">
-            <button>
-                close
-            </button>
-        </form>
-    </dialog>
-
-    <script>
+        <script>
   const imageInput = document.getElementById('id_image');
   const avatarPreview = document.getElementById('avatar-preview');
   const deleteBtn = document.getElementById('delete-avatar-btn');
@@ -413,5 +366,5 @@
     if (!submit) return;
     submit.disabled = input.value.trim() !== input.dataset.expectedUsername;
   }
-    </script>
-{% endblock %}
+        </script>
+    {% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -123,27 +123,25 @@
         </section>
 
         {# ── Profile Stats ───────────────────────────────────────────────────────── #}
-        <section class="flex flex-col gap-2">
+        <section class="card bg-primary-content flex flex-col gap-2 rounded-md p-4 shadow-sm">
             <p class="text-xs font-semibold text-base-content px-1">
                 {% trans "Stats" %}
             </p>
 
-            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 ">
                 {% for stat in profile_stats %}
-                    <div class="card bg-primary-content border border-gray-200 shadow-sm rounded-md p-4">
-                        <div class="flex items-start justify-between gap-3">
-                            <div>
-                                <p class="text-2xl font-semibold leading-none {{ stat.text_class }}">
-                                    {{ stat.value|default_if_none:"--" }}
-                                </p>
-                                <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                    {% trans stat.description %}
-                                </p>
-                            </div>
-                            <div class="{{ stat.icon_bg_class }} shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                    <div class="flex items-center justify-between gap-3 border border-gray-200 bg-base-200 rounded-xl p-2">
+                        <div class="flex flex-row gap-2 items-center">
+                            <div class="w-7 h-7 flex  items-center justify-center flex-shrink-0">
                                 {% heroicon_micro stat.icon class=stat.icon_class %}
                             </div>
+                            <p class="text-xs text-base-content">
+                                {% trans stat.description %}
+                            </p>
                         </div>
+                        <p class="text-xl font-semibold leading-none {{ stat.text_class }}">
+                            {{ stat.value|default_if_none:"--" }}
+                        </p>
                     </div>
                 {% endfor %}
             </section>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -133,7 +133,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <p class="text-2xl font-semibold leading-none text-success">
-                                {{ successful_borrows }}
+                                {{ successful_borrows|default:"--" }}
                             </p>
                             <p class="mt-2 text-xs leading-4 text-base-content/60">
                                 {% trans "Successful borrows" %}
@@ -149,7 +149,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <p class="text-2xl font-semibold leading-none text-success">
-                                {{ successful_lends }}
+                                {{ successful_lends|default:"--" }}
                             </p>
                             <p class="mt-2 text-xs leading-4 text-base-content/60">
                                 {% trans "Successful lends" %}
@@ -165,7 +165,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <p class="text-2xl font-semibold leading-none text-warning">
-                                {{ returns_requested }}
+                                {{ returns_requested|default:"--" }}
                             </p>
                             <p class="mt-2 text-xs leading-4 text-base-content/60">
                                 {% trans "Item returns requested" %}
@@ -181,7 +181,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <p class="text-2xl font-semibold leading-none text-error">
-                                {{ past_disputes }}
+                                {{ past_disputes|default:"--" }}
                             </p>
                             <p class="mt-2 text-xs leading-4 text-base-content/60">
                                 {% trans "Past disputes" %}

--- a/templates/users/public-profile.html
+++ b/templates/users/public-profile.html
@@ -30,20 +30,18 @@
                 </p>
                 <div class="grid w-full grid-cols-1 gap-3 pt-2 sm:grid-cols-2">
                     {% for stat in profile_context.profile_stats %}
-                        <div class="rounded-md border border-gray-200 bg-base-100 p-3">
-                            <div class="flex items-start justify-between gap-2">
-                                <div>
-                                    <p class="text-xl font-semibold leading-none {{ stat.text_class }}">
-                                        {{ stat.value|default_if_none:"--" }}
-                                    </p>
-                                    <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                        {% trans stat.description %}
-                                    </p>
-                                </div>
-                                <div class="{{ stat.icon_bg_class }} shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                        <div class="flex items-center justify-between gap-3 border border-gray-200 bg-base-200 rounded-xl p-2">
+                            <div class="flex flex-row gap-2 items-center">
+                                <div class="w-7 h-7 flex  items-center justify-center flex-shrink-0">
                                     {% heroicon_micro stat.icon class=stat.icon_class %}
                                 </div>
+                                <p class="text-xs text-base-content">
+                                    {% trans stat.description %}
+                                </p>
                             </div>
+                            <p class="text-xl font-semibold leading-none {{ stat.text_class }}">
+                                {{ stat.value|default_if_none:"--" }}
+                            </p>
                         </div>
                     {% endfor %}
                 </div>

--- a/templates/users/public-profile.html
+++ b/templates/users/public-profile.html
@@ -33,7 +33,7 @@
                         <div class="flex items-start justify-between gap-2">
                             <div>
                                 <p class="text-xl font-semibold leading-none text-success">
-                                    {{ profile_context.successful_borrows }}
+                                    {{ profile_context.successful_borrows|default:"--" }}
                                 </p>
                                 <p class="mt-2 text-xs leading-4 text-base-content/60">
                                     {% trans "Successful borrows" %}
@@ -49,7 +49,7 @@
                         <div class="flex items-start justify-between gap-2">
                             <div>
                                 <p class="text-xl font-semibold leading-none text-success">
-                                    {{ profile_context.successful_lends }}
+                                    {{ profile_context.successful_lends|default:"--" }}
                                 </p>
                                 <p class="mt-2 text-xs leading-4 text-base-content/60">
                                     {% trans "Successful lends" %}
@@ -65,7 +65,7 @@
                         <div class="flex items-start justify-between gap-2">
                             <div>
                                 <p class="text-xl font-semibold leading-none text-warning">
-                                    {{ profile_context.returns_requested }}
+                                    {{ profile_context.returns_requested|default:"--" }}
                                 </p>
                                 <p class="mt-2 text-xs leading-4 text-base-content/60">
                                     {% trans "Item returns requested" %}
@@ -81,7 +81,7 @@
                         <div class="flex items-start justify-between gap-2">
                             <div>
                                 <p class="text-xl font-semibold leading-none text-error">
-                                    {{ profile_context.past_disputes }}
+                                    {{ profile_context.past_disputes|default:"--" }}
                                 </p>
                                 <p class="mt-2 text-xs leading-4 text-base-content/60">
                                     {% trans "Past disputes" %}

--- a/templates/users/public-profile.html
+++ b/templates/users/public-profile.html
@@ -29,69 +29,23 @@
                     {% trans "A few Stats for trust" %}
                 </p>
                 <div class="grid w-full grid-cols-1 gap-3 pt-2 sm:grid-cols-2">
-                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
-                        <div class="flex items-start justify-between gap-2">
-                            <div>
-                                <p class="text-xl font-semibold leading-none text-success">
-                                    {{ profile_context.successful_borrows|default:"--" }}
-                                </p>
-                                <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                    {% trans "Successful borrows" %}
-                                </p>
-                            </div>
-                            <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                                {% heroicon_micro "check" class="w-4 h-4 text-success" %}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
-                        <div class="flex items-start justify-between gap-2">
-                            <div>
-                                <p class="text-xl font-semibold leading-none text-success">
-                                    {{ profile_context.successful_lends|default:"--" }}
-                                </p>
-                                <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                    {% trans "Successful lends" %}
-                                </p>
-                            </div>
-                            <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                                {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                    {% for stat in profile_context.profile_stats %}
+                        <div class="rounded-md border border-gray-200 bg-base-100 p-3">
+                            <div class="flex items-start justify-between gap-2">
+                                <div>
+                                    <p class="text-xl font-semibold leading-none {{ stat.text_class }}">
+                                        {{ stat.value|default_if_none:"--" }}
+                                    </p>
+                                    <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                        {% trans stat.description %}
+                                    </p>
+                                </div>
+                                <div class="{{ stat.icon_bg_class }} shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                    {% heroicon_micro stat.icon class=stat.icon_class %}
+                                </div>
                             </div>
                         </div>
-                    </div>
-
-                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
-                        <div class="flex items-start justify-between gap-2">
-                            <div>
-                                <p class="text-xl font-semibold leading-none text-warning">
-                                    {{ profile_context.returns_requested|default:"--" }}
-                                </p>
-                                <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                    {% trans "Item returns requested" %}
-                                </p>
-                            </div>
-                            <div class="bg-warning/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                                {% heroicon_micro "arrow-path-rounded-square" class="w-4 h-4 text-warning" %}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
-                        <div class="flex items-start justify-between gap-2">
-                            <div>
-                                <p class="text-xl font-semibold leading-none text-error">
-                                    {{ profile_context.past_disputes|default:"--" }}
-                                </p>
-                                <p class="mt-2 text-xs leading-4 text-base-content/60">
-                                    {% trans "Past disputes" %}
-                                </p>
-                            </div>
-                            <div class="bg-error/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
-                                {% heroicon_micro "exclamation-triangle" class="w-4 h-4 text-error" %}
-                            </div>
-                        </div>
-                    </div>
+                    {% endfor %}
                 </div>
 
             </section>

--- a/templates/users/public-profile.html
+++ b/templates/users/public-profile.html
@@ -1,5 +1,6 @@
 {% extends "layouts/default.html" %}
 
+{% load i18n %}
 {% load heroicons %}
 
 {% block content %}
@@ -22,6 +23,78 @@
             <div class="text-center font-inter text-sm font-normal leading-normal tracking-[-0.5px]">
                 {{ profile_context.bio|default:"This user hasn't added a bio yet." }}
             </div>
+
+            <section class="flex flex-col w-full gap-2">
+                <p class="text-xs font-semibold text-base-content px-1">
+                    {% trans "A few Stats for trust" %}
+                </p>
+                <div class="grid w-full grid-cols-1 gap-3 pt-2 sm:grid-cols-2">
+                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
+                        <div class="flex items-start justify-between gap-2">
+                            <div>
+                                <p class="text-xl font-semibold leading-none text-success">
+                                    {{ profile_context.successful_borrows }}
+                                </p>
+                                <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                    {% trans "Successful borrows" %}
+                                </p>
+                            </div>
+                            <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
+                        <div class="flex items-start justify-between gap-2">
+                            <div>
+                                <p class="text-xl font-semibold leading-none text-success">
+                                    {{ profile_context.successful_lends }}
+                                </p>
+                                <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                    {% trans "Successful lends" %}
+                                </p>
+                            </div>
+                            <div class="bg-success/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                {% heroicon_micro "check" class="w-4 h-4 text-success" %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
+                        <div class="flex items-start justify-between gap-2">
+                            <div>
+                                <p class="text-xl font-semibold leading-none text-warning">
+                                    {{ profile_context.returns_requested }}
+                                </p>
+                                <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                    {% trans "Item returns requested" %}
+                                </p>
+                            </div>
+                            <div class="bg-warning/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                {% heroicon_micro "arrow-path-rounded-square" class="w-4 h-4 text-warning" %}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-md border border-gray-200 bg-base-100 p-3">
+                        <div class="flex items-start justify-between gap-2">
+                            <div>
+                                <p class="text-xl font-semibold leading-none text-error">
+                                    {{ profile_context.past_disputes }}
+                                </p>
+                                <p class="mt-2 text-xs leading-4 text-base-content/60">
+                                    {% trans "Past disputes" %}
+                                </p>
+                            </div>
+                            <div class="bg-error/10 shadow-sm rounded w-7 h-7 flex items-center justify-center flex-shrink-0">
+                                {% heroicon_micro "exclamation-triangle" class="w-4 h-4 text-error" %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </section>
             {% if profile_context.email %}
                 <div class="text-[#757575]">
                     <span class="font-semibold">Email:</span> {{ profile_context.email }}


### PR DESCRIPTION
## Summary
Adds profile stats for Borrow'd users, showing successful borrows, successful lends, pending return requests, and past disputes on both private and public profile pages, backed by Transaction query helpers and focused tests.

## Other Improve Profile Stats (addressed In an upcoming PR)

The current four stats are a good foundation, these answer the basic trust question quickly: “Has this person borrowed, lent, returned, and disputed before?”

### More Interesting Stats

#### 1. Completion Rate

Show successful transactions as a percentage, not just a raw count.

Example: `Borrow return rate: 92%`
This gives better context than a single count. A user with 3 successful borrows out of 3 feels different from 3 successful borrows out of 20.

#### 2. Open Obligations(on private profile)
Show whether the user currently has active responsibilities.
Examples:
```
Currently borrowing: 2
Currently lending: 4
Return requested: 1
```
This helps the user see their summary.

#### 3. Dispute Context
Instead of only showing:
`Past disputes: 2`
show more context:
```
Disputes: 2 total
Resolved returned: 1
```
A dispute does not always mean the profile owner behaved badly, so resolution context makes the stat fairer.

#### 4. Trust Badges (need designs or mockups)
Transfer trust feature here by adding simple derived **trust** badges from the stats.

Possible rules:
`Reliable borrower:` 10+ successful borrows and 0 active return requests or `100% Return rate`
`Active lender:` 5+ successful lends
`Compliant member:` 0 disputes
`Generous member:` 5+ items given away

## Linked Issue(s)
Closes #482

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- Added Transaction query helpers for profile stats: successful borrows, successful lends, pending return requests, and past disputes.
- Added stats context to profile views so both private and public profile templates can render the same derived counters.
- Added profile stats UI to private and public profile pages, including responsive mobile layout and color-coded stat icons.
- Changed the profile details card to a **drawer** to make the page more breathable and limit scrolling.
- Added tests for the Transaction profile stat helpers.
- Used `disputed_at` to count disputes, since past disputes are tracked by dispute history rather than only current `DISPUTED` status.
- Items Given Away : Since OWNERSHIP_TRANSFERRED is different from lending, it is its own stat.

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Run `uv run manage.py test borrowd_items.tests.test_transaction_query_helpers`.
2. View your own profile and confirm all four stats are visible, including zero values.
3. View another user's public profile and confirm the same stats appear in the adapted public-profile layout.
4. Create or inspect transactions in `RETURN_REQUESTED` and `RETURN_ASSERTED` states and confirm both are counted in pending return requests.

## Screenshots (if UI change)
<!-- Before / After if applicable -->
<img width="676" height="262" alt="Screenshot 2026-07-12 at 4 32 54 PM" src="https://github.com/user-attachments/assets/01dc3368-7ada-464d-b218-cde690a4351d" />


## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
- `get_pending_return_requests()` intentionally counts both `RETURN_REQUESTED` and `RETURN_ASSERTED`, instead of only `RETURN_ASSERTED`, because the return request flow starts when the transaction enters `RETURN_REQUESTED`.
- The PRD has conflicting language around `OWNERSHIP_TRANSFERRED`: one section says it should not inflate Successful Lends, while another says it should increment Successful Lends. This PR currently counts `OWNERSHIP_TRANSFERRED` for the lender, but **I recommend** clarifying the behaviour we want and potentially moving giveaways into a separate future stat such as “Items given away.”