### PR TITLE
Change default for skip_e2e input to true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   e2e:
     name: E2E tests (Playwright/Python)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     continue-on-error: true
     if: ${{ !inputs.skip_e2e }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       skip_e2e:
         description: "Skip E2E tests"
         type: boolean
-        default: false
+        default: true
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Skip e2e

## Summary
<!-- What does this PR do? One paragraph max. -->
Skip E2E tests for now 


## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
-
-

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1.
2.

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [ ] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
