### PR TITLE
cache-like bulk precomptuted item state to prevent unnecessary db round trips 

### DIFF
--- a/borrowd_items/card_helpers.py
+++ b/borrowd_items/card_helpers.py
@@ -7,20 +7,25 @@ used throughout the application.
 
 from typing import TYPE_CHECKING, Any
 
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.text import capfirst
 
 from .models import (
+    AvailabilitySubscription,
     AvailabilitySubscriptionStatus,
+    Item,
     ItemAction,
     ItemActionContext,
+    ItemStatus,
+    PrecomputedItemState,
+    Transaction,
+    TransactionStatus,
 )
 
 if TYPE_CHECKING:
     from borrowd_users.models import BorrowdUser
-
-    from .models import Item, Transaction
 
 
 # Giveaway listings, offers, and pending requests share the gift icon.
@@ -63,6 +68,217 @@ BANNER_STYLES = {
     "giveaway_requested": {"bg": "bg-primary/15", "text": "text-primary"},
 }
 
+_TERMINAL_TRANSACTION_STATUSES = (
+    TransactionStatus.RETURNED,
+    TransactionStatus.REJECTED,
+    TransactionStatus.CANCELLED,
+    TransactionStatus.RESOLVED,
+    TransactionStatus.OWNERSHIP_TRANSFERRED,
+)
+
+_REQUEST_TRANSACTION_STATUSES = (
+    TransactionStatus.REQUESTED,
+    TransactionStatus.GIVEAWAY_REQUESTED,
+)
+
+_BORROWER_TRANSACTION_STATUSES = (
+    TransactionStatus.ACCEPTED,
+    TransactionStatus.COLLECTION_ASSERTED,
+    TransactionStatus.COLLECTED,
+    TransactionStatus.GIVEAWAY_OFFERED,
+    TransactionStatus.RETURN_REQUESTED,
+    TransactionStatus.RETURN_ASSERTED,
+    TransactionStatus.DISPUTED,
+)
+
+_TRANSACTION_SELECT_RELATED = (
+    "party1",
+    "party1__profile",
+    "party2",
+    "party2__profile",
+    "updated_by",
+)
+
+_ITEM_SELECT_RELATED = ("owner", "owner__profile")
+
+_CARD_TRANSACTION_SELECT_RELATED = (
+    *_TRANSACTION_SELECT_RELATED,
+    "item",
+    "item__owner",
+    "item__owner__profile",
+)
+
+
+def with_card_relations(queryset: "QuerySet[Item]") -> "QuerySet[Item]":
+    """
+    Apply the select_related/prefetch_related an item card needs.
+
+    Callers building a queryset of Items destined for
+    build_item_cards_for_items() should wrap it with this before
+    evaluating it, so owner/profile/photo access doesn't cost a query
+    per card. If a caller forgets, cards still render correctly -- just
+    with a query per card instead of one for the whole list.
+    """
+    return queryset.select_related(*_ITEM_SELECT_RELATED).prefetch_related("photos")
+
+
+def with_card_relations_for_transactions(
+    queryset: "QuerySet[Transaction]",
+) -> "QuerySet[Transaction]":
+    """
+    Apply the select_related/prefetch_related an item card needs when
+    rendering from a Transaction queryset.
+
+    Callers building a queryset of Transactions destined for
+    build_item_cards_for_transactions() should wrap it with this before
+    evaluating it. If a caller forgets, cards still render correctly --
+    just with a query per card instead of one for the whole list.
+    """
+    return queryset.select_related(*_CARD_TRANSACTION_SELECT_RELATED).prefetch_related(
+        "item__photos"
+    )
+
+
+def _state_from_transaction(
+    transaction: Transaction | None,
+    *,
+    has_active_subscription: bool = False,
+) -> PrecomputedItemState:
+    """
+    Derive card state from an already-loaded transaction without querying the db.
+
+    Both action context and banner rendering need borrower/requester/current
+    transaction state, so centralizing the derivation lets them share the same
+    in-memory facts.
+    """
+    current_borrower = None
+    requesting_user = None
+
+    if transaction is not None:
+        if transaction.status in _REQUEST_TRANSACTION_STATUSES:
+            requesting_user = transaction.party2
+        elif transaction.status in _BORROWER_TRANSACTION_STATUSES:
+            current_borrower = transaction.party2
+
+    return PrecomputedItemState(
+        current_borrower=current_borrower,
+        requesting_user=requesting_user,
+        current_transaction=transaction,
+        has_active_subscription=has_active_subscription,
+    )
+
+
+def _active_subscription_item_ids(
+    item_ids: list[int],
+    user: "BorrowdUser",
+) -> set[int]:
+    """
+    Fetch active subscription flags for all card items in one query.
+
+    Without this batch lookup, unavailable item cards can each check whether
+    the viewing user has an active notify-me subscription.
+    """
+    if not item_ids:
+        return set()
+
+    return set(
+        AvailabilitySubscription.objects.filter(
+            item_id__in=item_ids,
+            user=user,
+            status=AvailabilitySubscriptionStatus.ACTIVE,
+        ).values_list("item_id", flat=True)
+    )
+
+
+def _precompute_item_states_for_items(
+    items: list["Item"],
+    user: "BorrowdUser",
+) -> dict[int, PrecomputedItemState]:
+    """
+    Build per-item card state (cache-like) for an item list with batch queries.
+
+    This replaces repeated get_current_borrower/get_requesting_user/
+    get_current_transaction/subscription calls while rendering item grids.
+    """
+    item_ids = [item.pk for item in items]
+    if not item_ids:
+        return {}
+
+    current_transactions: dict[int, Transaction] = {}
+    for transaction in (
+        Transaction.objects.filter(item_id__in=item_ids)
+        .exclude(status__in=_TERMINAL_TRANSACTION_STATUSES)
+        .select_related(*_TRANSACTION_SELECT_RELATED)
+        .order_by("item_id", "-created_at")
+    ):
+        current_transactions.setdefault(transaction.item_id, transaction)
+
+    subscription_item_ids = _active_subscription_item_ids(item_ids, user)
+
+    return {
+        item_id: _state_from_transaction(
+            current_transactions.get(item_id),
+            has_active_subscription=item_id in subscription_item_ids,
+        )
+        for item_id in item_ids
+    }
+
+
+def _precompute_item_states_for_transactions(
+    transactions: list[Transaction],
+    user: "BorrowdUser",
+) -> dict[int, PrecomputedItemState]:
+    """
+    Build per-transaction card state (cache-like) from the loaded transaction rows.
+
+    Transaction sections already know the active transaction, so this avoids
+    asking the database to rediscover the same current transaction per card.
+    """
+    item_ids = [transaction.item_id for transaction in transactions]
+    if not item_ids:
+        return {}
+
+    subscription_item_ids = _active_subscription_item_ids(item_ids, user)
+
+    return {
+        transaction.pk: _state_from_transaction(
+            transaction,
+            has_active_subscription=transaction.item_id in subscription_item_ids,
+        )
+        for transaction in transactions
+    }
+
+
+def _precompute_item_state(
+    item: "Item",
+    user: "BorrowdUser",
+) -> PrecomputedItemState:
+    """
+    Build card state for a single item when no batch state was cached or supplied.
+
+    This preserves the standalone build_item_card_context() API while keeping
+    its action-context and banner paths on one shared state object.
+    """
+    current_transaction = item.get_current_transaction()
+    needs_subscription_state = item.owner_id != user.id and (
+        current_transaction is not None or item.status != ItemStatus.AVAILABLE
+    )
+    has_active_subscription = (
+        bool(
+            AvailabilitySubscription.objects.filter(
+                item=item,
+                user=user,
+                status=AvailabilitySubscriptionStatus.ACTIVE,
+            ).exists()
+        )
+        if needs_subscription_state
+        else False
+    )
+    return _state_from_transaction(
+        current_transaction,
+        has_active_subscription=has_active_subscription,
+    )
+
 
 def build_card_ids(context: str, pk: int) -> dict[str, str]:
     """
@@ -99,7 +315,9 @@ def build_card_ids(context: str, pk: int) -> dict[str, str]:
 
 
 def get_banner_info_for_item(
-    item: "Item", viewing_user: "BorrowdUser"
+    item: "Item",
+    viewing_user: "BorrowdUser",
+    precomputed: "PrecomputedItemState | None" = None,
 ) -> dict[str, str]:
     """
     Get banner type and request info, checking for pending requests.
@@ -119,6 +337,9 @@ def get_banner_info_for_item(
         viewing_user: The user viewing the card
             for "me" substitution
             determines what info is shown
+        precomputed: current_borrower/requesting_user, if the caller
+            already derived them (e.g. alongside action context for the
+            same item) and wants to skip re-deriving them here.
 
     Returns:
         Dict with banner_type (str),
@@ -140,33 +361,15 @@ def get_banner_info_for_item(
     """
     from django.utils.timesince import timesince
 
-    from .models import ListingType, TransactionStatus
+    from .models import ListingType
 
     # Check for active transaction to determine banner state
-    current_borrower = item.get_current_borrower()
-    requesting_user = item.get_requesting_user()
+    if precomputed is None:
+        precomputed = _precompute_item_state(item, viewing_user)
 
-    # Get current transaction for this item
-    current_transaction = None
-    if current_borrower or requesting_user:
-        current_transaction = (
-            item.transactions.select_related("party2")
-            .filter(
-                status__in=[
-                    TransactionStatus.REQUESTED,
-                    TransactionStatus.GIVEAWAY_REQUESTED,
-                    TransactionStatus.ACCEPTED,
-                    TransactionStatus.COLLECTION_ASSERTED,
-                    TransactionStatus.COLLECTED,
-                    TransactionStatus.GIVEAWAY_OFFERED,
-                    TransactionStatus.RETURN_REQUESTED,
-                    TransactionStatus.RETURN_ASSERTED,
-                    TransactionStatus.DISPUTED,
-                ]
-            )
-            .order_by("-created_at")
-            .first()
-        )
+    current_borrower = precomputed.current_borrower
+    requesting_user = precomputed.requesting_user
+    current_transaction = precomputed.current_transaction
 
     if not current_transaction:
         # No active transaction; a giveaway listing advertises itself.
@@ -178,24 +381,21 @@ def get_banner_info_for_item(
     if (
         requesting_user != viewing_user
         and current_borrower != viewing_user
-        and item.subscriptions.filter(
-            status=AvailabilitySubscriptionStatus.ACTIVE,
-            user=viewing_user,
-        ).exists()
+        and precomputed.has_active_subscription
     ):
         return {"banner_type": "waitlisted"}
 
     # Return-request, giveaway, and dispute banners only concern the two
     # parties; everyone else sees the generic borrowed label.
     if current_transaction.status == TransactionStatus.DISPUTED:
-        if item.owner == viewing_user or current_borrower == viewing_user:
+        if item.owner_id == viewing_user.id or current_borrower == viewing_user:
             return {"banner_type": "disputed"}
         return {"banner_type": "borrowed"}
 
     # giveaway banner: owner sees "Giveaway Offered",
     # borrower sees the offer with the lender's name.
     if current_transaction.status == TransactionStatus.GIVEAWAY_OFFERED:
-        if item.owner == viewing_user:
+        if item.owner_id == viewing_user.id:
             return {"banner_type": "giveaway_offered"}
         if current_borrower == viewing_user:
             return {
@@ -207,7 +407,7 @@ def get_banner_info_for_item(
     # giveaway-request banner: owner sees who's asking, the requester sees
     # their request is pending, everyone else sees the generic pending label.
     if current_transaction.status == TransactionStatus.GIVEAWAY_REQUESTED:
-        if item.owner == viewing_user:
+        if item.owner_id == viewing_user.id:
             return {
                 "banner_type": "giveaway_requested",
                 "person_name": capfirst(current_transaction.party2.first_name),
@@ -229,7 +429,7 @@ def get_banner_info_for_item(
         )
     )
     if return_request_open:
-        if item.owner == viewing_user:
+        if item.owner_id == viewing_user.id:
             return {"banner_type": "return_requested", "person_name": "you"}
         if current_borrower == viewing_user:
             return {
@@ -267,7 +467,7 @@ def get_banner_info_for_item(
         defining `person_name` and `person_url` below"""
         return {"banner_type": "available"}
 
-    viewing_user_is_item_owner = item.owner == viewing_user
+    viewing_user_is_item_owner = item.owner_id == viewing_user.id
     viewing_user_is_borrower = user_whose_name_should_be_shown_in_banner == viewing_user
 
     # Everyone except the owner and the person in the transaction gets a
@@ -305,6 +505,7 @@ def build_item_card_context(
     user: "BorrowdUser",
     context: str,
     action_context: "ItemActionContext | None" = None,
+    precomputed: "PrecomputedItemState | None" = None,
     error_message: str | None = None,
     error_type: str | None = None,
 ) -> dict[str, Any]:
@@ -319,14 +520,23 @@ def build_item_card_context(
         user: The viewing user (for permissions and "me" substitution)
         context: The card context/section (e.g., "search", "my-items")
         action_context: Pre-computed action context, or None to compute it
+        precomputed: Pre-computed item state, or None to compute it
         error_message: Optional error message to display
         error_type: Optional error type (e.g., "already_requested")
 
     Returns:
         Dict with all context variables needed by item_card.html template.
     """
+    # current_borrower/requesting_user are viewer-independent, so computing
+    # them once here lets both get_action_context_for and
+    # get_banner_info_for_item skip re-deriving them below.
     if action_context is None:
-        action_context = item.get_action_context_for(user=user)
+        if precomputed is None:
+            precomputed = _precompute_item_state(item, user)
+        action_context = item.get_action_context_for(
+            user=user,
+            precomputed=precomputed,
+        )
 
     # Once the request is approved, the card only shows "Confirm picked up".
     # Cancel is still accessible on the item detail page.
@@ -343,8 +553,11 @@ def build_item_card_context(
             waiting_text=action_context.waiting_text,
         )
 
-    first_photo = item.photos.first()
-    banner_info = get_banner_info_for_item(item, user)
+    # item.photos.first() would build a fresh ordered queryset and bypass
+    # any prefetch_related("photos") the caller set up; this reads the
+    # prefetch cache when present.
+    first_photo = next(iter(item.photos.all()), None)
+    banner_info = get_banner_info_for_item(item, user, precomputed=precomputed)
     card_ids = build_card_ids(context, item.pk)
 
     # Get banner styling
@@ -371,7 +584,7 @@ def build_item_card_context(
         "name": item.name,
         "description": item.description,
         "image": image,
-        "is_yours": item.owner == user,
+        "is_yours": item.owner_id == user.id,
         "is_removed": is_removed,
         "banner_type": banner_type,
         "banner_bg": banner_style.get("bg", ""),
@@ -398,14 +611,25 @@ def build_item_cards_for_items(
     Build card contexts for a list of items.
 
     Args:
-        items: List of Item objects to render
+        items: List of Item objects to render. Build the queryset this list
+            came from with with_card_relations() so owner/profile/photo
+            access doesn't cost a query per card.
         user: The viewing user
         context: The card context/section (e.g., "search", "my-items")
 
     Returns:
         List of context dicts for item_card.html template.
     """
-    return [build_item_card_context(item, user, context) for item in items]
+    precomputed_by_item_id = _precompute_item_states_for_items(items, user)
+    return [
+        build_item_card_context(
+            item,
+            user,
+            context,
+            precomputed=precomputed_by_item_id[item.pk],
+        )
+        for item in items
+    ]
 
 
 def build_item_cards_for_transactions(
@@ -417,17 +641,28 @@ def build_item_cards_for_transactions(
     Extracts the item from each transaction and builds card context.
 
     Args:
-        transactions: List of Transaction objects
+        transactions: List of Transaction objects. Build the queryset this
+            list came from with with_card_relations_for_transactions() so
+            party/item/photo access doesn't cost a query per card.
         user: The viewing user
         context: The card context/section (e.g., "incoming-borrow-requests")
 
     Returns:
         List of context dicts for item_card.html template.
     """
+    precomputed_by_transaction_id = _precompute_item_states_for_transactions(
+        transactions,
+        user,
+    )
     return [
         # ForeignKey type not fully resolved without django-stubs mypy plugin
         # Ref: https://forum.djangoproject.com/t/mypy-and-type-checking/15787,
         # Ref: https://github.com/typeddjango/django-stubs
-        build_item_card_context(transaction.item, user, context)
+        build_item_card_context(
+            transaction.item,
+            user,
+            context,
+            precomputed=precomputed_by_transaction_id[transaction.pk],
+        )
         for transaction in transactions
     ]

--- a/borrowd_items/card_helpers.py
+++ b/borrowd_items/card_helpers.py
@@ -13,6 +13,9 @@ from django.utils.html import format_html
 from django.utils.text import capfirst
 
 from .models import (
+    BORROWER_TRANSACTION_STATUSES,
+    REQUEST_TRANSACTION_STATUSES,
+    TERMINAL_TRANSACTION_STATUSES,
     AvailabilitySubscription,
     AvailabilitySubscriptionStatus,
     Item,
@@ -67,29 +70,6 @@ BANNER_STYLES = {
     "giveaway_listing": {"bg": "bg-primary/15", "text": "text-primary"},
     "giveaway_requested": {"bg": "bg-primary/15", "text": "text-primary"},
 }
-
-_TERMINAL_TRANSACTION_STATUSES = (
-    TransactionStatus.RETURNED,
-    TransactionStatus.REJECTED,
-    TransactionStatus.CANCELLED,
-    TransactionStatus.RESOLVED,
-    TransactionStatus.OWNERSHIP_TRANSFERRED,
-)
-
-_REQUEST_TRANSACTION_STATUSES = (
-    TransactionStatus.REQUESTED,
-    TransactionStatus.GIVEAWAY_REQUESTED,
-)
-
-_BORROWER_TRANSACTION_STATUSES = (
-    TransactionStatus.ACCEPTED,
-    TransactionStatus.COLLECTION_ASSERTED,
-    TransactionStatus.COLLECTED,
-    TransactionStatus.GIVEAWAY_OFFERED,
-    TransactionStatus.RETURN_REQUESTED,
-    TransactionStatus.RETURN_ASSERTED,
-    TransactionStatus.DISPUTED,
-)
 
 _TRANSACTION_SELECT_RELATED = (
     "party1",
@@ -155,9 +135,9 @@ def _state_from_transaction(
     requesting_user = None
 
     if transaction is not None:
-        if transaction.status in _REQUEST_TRANSACTION_STATUSES:
+        if transaction.status in REQUEST_TRANSACTION_STATUSES:
             requesting_user = transaction.party2
-        elif transaction.status in _BORROWER_TRANSACTION_STATUSES:
+        elif transaction.status in BORROWER_TRANSACTION_STATUSES:
             current_borrower = transaction.party2
 
     return PrecomputedItemState(
@@ -207,7 +187,7 @@ def _precompute_item_states_for_items(
     current_transactions: dict[int, Transaction] = {}
     for transaction in (
         Transaction.objects.filter(item_id__in=item_ids)
-        .exclude(status__in=_TERMINAL_TRANSACTION_STATUSES)
+        .exclude(status__in=TERMINAL_TRANSACTION_STATUSES)
         .select_related(*_TRANSACTION_SELECT_RELATED)
         .order_by("item_id", "-created_at")
     ):

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -111,6 +111,20 @@ class ItemActionContext:
     waiting_text: Optional[str] = None
 
 
+@dataclass
+class PrecomputedItemState:
+    """
+    Item card state computed once by a caller that's about to ask for both
+    action context and banner info for the same item, so neither has to
+    re-derive it independently.
+    """
+
+    current_borrower: Optional[BorrowdUser]
+    requesting_user: Optional[BorrowdUser]
+    current_transaction: Optional["Transaction"]
+    has_active_subscription: bool = False
+
+
 class ItemCategory(Model):
     name = CharField(max_length=50, null=False, blank=False)
     description = CharField(max_length=100, null=True, blank=True)
@@ -243,16 +257,37 @@ class Item(Model):
         self.deleted_by = deleted_by
         self.save()
 
-    def get_action_context_for(self, user: BorrowdUser) -> ItemActionContext:
+    def get_action_context_for(
+        self,
+        user: BorrowdUser,
+        precomputed: Optional[PrecomputedItemState] = None,
+    ) -> ItemActionContext:
         """
         Returns ItemActionContext containing ItemActions [e.g. REQUEST_ITEM, ACCEPT_REQUEST]
         and status information [e.g. "You are currently borrowing this item."] for the given user.
+
+        `precomputed`, if given, skips re-deriving current_borrower/
+        requesting_user for callers that already computed them (e.g. to
+        also build banner info for the same item without asking twice).
         """
 
-        current_borrower = self.get_current_borrower()
-        requesting_user = self.get_requesting_user()
-        current_tx = self.get_current_transaction_for_user(user)
-        actions = self.get_actions_for(user)
+        if precomputed is not None:
+            current_borrower = precomputed.current_borrower
+            requesting_user = precomputed.requesting_user
+            current_tx = (
+                precomputed.current_transaction
+                if precomputed.current_transaction
+                and (
+                    precomputed.current_transaction.party1_id == user.id
+                    or precomputed.current_transaction.party2_id == user.id
+                )
+                else None
+            )
+        else:
+            current_borrower = self.get_current_borrower()
+            requesting_user = self.get_requesting_user()
+            current_tx = self.get_current_transaction_for_user(user)
+        actions = self.get_actions_for(user, precomputed=precomputed)
 
         # Generate status text based on user role and current actions/status
         status_text = self._get_status_text_for_user(
@@ -261,6 +296,7 @@ class Item(Model):
             current_borrower=current_borrower,
             requesting_user=requesting_user,
             current_tx=current_tx,
+            precomputed=precomputed,
         )
 
         # The borrower who asserted return of a requested item must wait for
@@ -270,7 +306,7 @@ class Item(Model):
             current_tx is not None
             and current_tx.status == TransactionStatus.RETURN_ASSERTED
             and current_tx.return_requested_at is not None
-            and current_tx.updated_by == user
+            and current_tx.updated_by_id == user.id
         ):
             waiting_text = "Waiting on confirmation from lender..."
 
@@ -285,10 +321,11 @@ class Item(Model):
         current_borrower: Optional[BorrowdUser],
         requesting_user: Optional[BorrowdUser],
         current_tx: Optional["Transaction"] = None,
+        precomputed: Optional[PrecomputedItemState] = None,
     ) -> str:
         """Generate context-appropriate status text for the user."""
         # Determine user role
-        is_owner = self.owner == user
+        is_owner = self.owner_id == user.id
         is_borrower = current_borrower and current_borrower == user
 
         # Get display names (with privacy considerations)
@@ -306,7 +343,7 @@ class Item(Model):
         elif is_borrower:
             return self._get_borrower_status_text(actions, current_tx)
         else:
-            return self._get_other_user_status_text(actions, user)
+            return self._get_other_user_status_text(actions, user, precomputed)
 
     def _get_owner_status_text(
         self,
@@ -386,7 +423,10 @@ class Item(Model):
             return "Not available for borrowing"
 
     def _get_other_user_status_text(
-        self, actions: tuple[ItemAction, ...], user: BorrowdUser
+        self,
+        actions: tuple[ItemAction, ...],
+        user: BorrowdUser,
+        precomputed: Optional[PrecomputedItemState] = None,
     ) -> str:
         """Generate status text for users who are neither owner nor borrower."""
         if len(actions) == 1 and ItemAction.CANCEL_REQUEST in actions:
@@ -398,20 +438,29 @@ class Item(Model):
             return "Available to request!"
         elif ItemAction.REQUEST_GIVEAWAY in actions:
             return "Free to keep!"
+        elif precomputed is not None and precomputed.has_active_subscription:
+            return "You've requested to be notified when this item is available again."
         elif (
-            AvailabilitySubscription.get_active_subscription_for_user_and_item(
+            precomputed is None
+            and AvailabilitySubscription.get_active_subscription_for_user_and_item(
                 user=user, item=self
             )
             is not None
         ):
             return "You've requested to be notified when this item is available again."
-        elif self.get_requesting_user() is not None:
+        elif precomputed is not None and precomputed.requesting_user is not None:
+            return "Item is reserved"
+        elif precomputed is None and self.get_requesting_user() is not None:
             # There's a pending request from another user
             return "Item is reserved"
         else:
             return "Not available for borrowing"
 
-    def get_actions_for(self, user: BorrowdUser) -> tuple[ItemAction, ...]:
+    def get_actions_for(
+        self,
+        user: BorrowdUser,
+        precomputed: Optional[PrecomputedItemState] = None,
+    ) -> tuple[ItemAction, ...]:
         """
         Returns a tuple of ItemAction objects representing the
         current valid actions that the given User may perform on this
@@ -424,7 +473,24 @@ class Item(Model):
         """
         # This may raise Transaction.MultipleObjectsReturned.
         # Let it propagate.
-        current_tx = self.get_current_transaction_for_user(user)
+        if precomputed is not None:
+            current_tx = (
+                precomputed.current_transaction
+                if precomputed.current_transaction
+                and (
+                    precomputed.current_transaction.party1_id == user.id
+                    or precomputed.current_transaction.party2_id == user.id
+                )
+                else None
+            )
+            current_borrower = precomputed.current_borrower
+            requesting_user = precomputed.requesting_user
+            has_active_subscription = precomputed.has_active_subscription
+        else:
+            current_tx = self.get_current_transaction_for_user(user)
+            current_borrower = self.get_current_borrower()
+            requesting_user = self.get_requesting_user()
+            has_active_subscription = None
 
         # IF there are no current Txns involving this user...
         if current_tx is None:
@@ -433,8 +499,8 @@ class Item(Model):
             #   AND there's no pending request from another user
             if (
                 self.status == ItemStatus.AVAILABLE
-                and self.owner != user
-                and self.get_requesting_user() is None
+                and self.owner_id != user.id
+                and requesting_user is None
             ):
                 # THEN
                 #   the User can Request the Item,
@@ -442,36 +508,44 @@ class Item(Model):
                 if self.listing_type == ListingType.GIVEAWAY:
                     return (ItemAction.REQUEST_GIVEAWAY,)
                 return (ItemAction.REQUEST_ITEM,)
-            elif (
-                not self.is_borrowable(user=user)
-                and AvailabilitySubscription.get_active_subscription_for_user_and_item(
-                    user=user, item=self
-                )
-                is None
-            ) and self.owner != user:
+            is_borrowable = (
+                self.status == ItemStatus.AVAILABLE
+                and current_borrower is None
+                and (requesting_user is None or requesting_user == user)
+            )
+            if not is_borrowable and self.owner_id != user.id:
+                if has_active_subscription is None:
+                    has_active_subscription = AvailabilitySubscription.objects.filter(
+                        user=user,
+                        item=self,
+                        status=AvailabilitySubscriptionStatus.ACTIVE,
+                    ).exists()
+            if (
+                not is_borrowable
+                and not has_active_subscription
+                and self.owner_id != user.id
+            ):
                 # If the item is currently BORROWED or RESERVED by another user,
                 # allow requesting notification for when it becomes available again
                 return (ItemAction.NOTIFY_WHEN_AVAILABLE,)
-            elif (
-                not self.is_borrowable(user=user)
-                and AvailabilitySubscription.get_active_subscription_for_user_and_item(
-                    user=user, item=self
-                )
-                is not None
-            ) and self.owner != user:
+            if (
+                not is_borrowable
+                and has_active_subscription
+                and self.owner_id != user.id
+            ):
                 # If the item is currently BORROWED or RESERVED by another user,
                 # but the current user has an active subscription, allow cancelling the subscription
                 return (ItemAction.CANCEL_NOTIFICATION_REQUEST,)
-            else:
-                # At this point, either:
-                # - the user is the owner of the item (and thus can't request to borrow their
-                # no Request can be initiated.
 
-                # NOTE Later we may want to allow new Requests on Items
-                # even when they're currently Borrowed; that will
-                # imply date-based borrowing bookings, which we're
-                # not tackling yet.
-                return tuple()
+            # At this point, either:
+            # - the user is the owner of the item (and thus can't request to borrow their
+            # no Request can be initiated.
+
+            # NOTE Later we may want to allow new Requests on Items
+            # even when they're currently Borrowed; that will
+            # imply date-based borrowing bookings, which we're
+            # not tackling yet.
+            return tuple()
 
         # If we get here, we have exactly one Transaction involving
         # this Item and this User. Let's figure out what are the
@@ -496,7 +570,7 @@ class Item(Model):
                 return (ItemAction.RESOLVE_TRANSACTION,)
 
         if current_tx.status == TransactionStatus.REQUESTED:
-            if self.owner == user:
+            if self.owner_id == user.id:
                 # The User is the owner of the Item, and the current
                 # Transaction is a Request from another User.
                 # The owner can either Accept or Reject the Request.
@@ -511,7 +585,7 @@ class Item(Model):
                 # but may cancel.
                 return (ItemAction.CANCEL_REQUEST,)
         elif current_tx.status == TransactionStatus.GIVEAWAY_REQUESTED:
-            if self.owner == user:
+            if self.owner_id == user.id:
                 # The owner decides whether to hand the item over.
                 return (
                     ItemAction.DECLINE_GIVEAWAY_REQUEST,
@@ -527,7 +601,7 @@ class Item(Model):
             )
         elif current_tx.status == TransactionStatus.COLLECTION_ASSERTED:
             # Make sure the same person doesn't confirm the assertion
-            if current_tx.updated_by != user:
+            if current_tx.updated_by_id != user.id:
                 # TODO: What's the escape hatch if a dispute arises?
                 return (ItemAction.CONFIRM_COLLECTED,)
             else:
@@ -536,7 +610,7 @@ class Item(Model):
         elif current_tx.status == TransactionStatus.COLLECTED:
             # Either borrower or lender can assert return.
             # The lender can also request the item back, or give it away.
-            if self.owner == user:
+            if self.owner_id == user.id:
                 return (
                     ItemAction.MARK_RETURNED,
                     ItemAction.REQUEST_RETURN,
@@ -546,11 +620,11 @@ class Item(Model):
         elif current_tx.status == TransactionStatus.GIVEAWAY_OFFERED:
             # The borrower decides whether to accept the gift.
             # The lender waits on that decision.
-            if self.owner == user:
+            if self.owner_id == user.id:
                 return tuple()
             return (ItemAction.ACCEPT_GIVEAWAY, ItemAction.DECLINE_GIVEAWAY)
         elif current_tx.status == TransactionStatus.RETURN_REQUESTED:
-            if self.owner == user:
+            if self.owner_id == user.id:
                 # The lender can escalate to a dispute only if the wait window has passed
                 if current_tx.dispute_wait_has_elapsed():
                     return (ItemAction.RAISE_DISPUTE, ItemAction.CONFIRM_RETURNED)
@@ -559,8 +633,8 @@ class Item(Model):
             return (ItemAction.MARK_RETURNED, ItemAction.FLAG_CANNOT_RETURN)
         elif current_tx.status == TransactionStatus.RETURN_ASSERTED:
             # Make sure the same person doesn't confirm the assertion
-            if current_tx.updated_by != user:
-                if self.owner == user:
+            if current_tx.updated_by_id != user.id:
+                if self.owner_id == user.id:
                     # The lender can deny the borrower's return claim.
                     return (ItemAction.RAISE_DISPUTE, ItemAction.CONFIRM_RETURNED)
                 return (ItemAction.CONFIRM_RETURNED,)
@@ -568,7 +642,7 @@ class Item(Model):
                 # Otherwise, nothing to do but wait...
                 return tuple()
         elif current_tx.status == TransactionStatus.DISPUTED:
-            if self.owner == user:
+            if self.owner_id == user.id:
                 # The lender settles the dispute one way or the other.
                 return (
                     ItemAction.RESOLVE_DISPUTE_NOT_RETURNED,
@@ -656,6 +730,34 @@ class Item(Model):
                 .first()
             )
             return txn.party2 if txn else None
+
+    def get_current_transaction(self) -> Optional["Transaction"]:
+        """
+        Returns the transaction involving this item regardless of the user
+        """
+        try:
+            # Using `get()` here because if there *is* a current Active
+            # Transaction involving this Item , there should only be one.
+            # Related user data is loaded for card/status text rendering.
+            return Transaction.objects.select_related(
+                "party1",
+                "party1__profile",
+                "party2",
+                "party2__profile",
+            ).get(
+                Q(item=self)
+                & ~Q(
+                    status__in=[
+                        TransactionStatus.RETURNED,
+                        TransactionStatus.REJECTED,
+                        TransactionStatus.CANCELLED,
+                        TransactionStatus.RESOLVED,
+                        TransactionStatus.OWNERSHIP_TRANSFERRED,
+                    ]
+                )
+            )
+        except Transaction.DoesNotExist:
+            return None
 
     def get_current_transaction_for_user(
         self, user: BorrowdUser

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -660,13 +660,9 @@ class Item(Model):
         Returns the User with an open borrow or giveaway request on
         this Item, if any.
         """
-        pending_statuses = [
-            TransactionStatus.REQUESTED,
-            TransactionStatus.GIVEAWAY_REQUESTED,
-        ]
         try:
             transaction = Transaction.objects.get(
-                Q(item=self) & Q(status__in=pending_statuses)
+                Q(item=self) & Q(status__in=REQUEST_TRANSACTION_STATUSES)
             )
             # party2 is the requestor
             return transaction.party2
@@ -676,7 +672,7 @@ class Item(Model):
             # Return the most recent request (for now)
             txn: Optional["Transaction"] = (
                 Transaction.objects.filter(
-                    Q(item=self) & Q(status__in=pending_statuses)
+                    Q(item=self) & Q(status__in=REQUEST_TRANSACTION_STATUSES)
                 )
                 .order_by("-created_at")
                 .first()
@@ -690,18 +686,7 @@ class Item(Model):
         # Look for an active transaction where the item is borrowed or reserved
         try:
             transaction = Transaction.objects.get(
-                Q(item=self)
-                & Q(
-                    status__in=[
-                        TransactionStatus.ACCEPTED,
-                        TransactionStatus.COLLECTION_ASSERTED,
-                        TransactionStatus.COLLECTED,
-                        TransactionStatus.GIVEAWAY_OFFERED,
-                        TransactionStatus.RETURN_REQUESTED,
-                        TransactionStatus.RETURN_ASSERTED,
-                        TransactionStatus.DISPUTED,
-                    ]
-                )
+                Q(item=self) & Q(status__in=BORROWER_TRANSACTION_STATUSES)
             )
             # party2 is the borrower
             return transaction.party2
@@ -712,18 +697,7 @@ class Item(Model):
             # return the most recent one
             txn: Optional["Transaction"] = (
                 Transaction.objects.filter(
-                    Q(item=self)
-                    & Q(
-                        status__in=[
-                            TransactionStatus.ACCEPTED,
-                            TransactionStatus.COLLECTION_ASSERTED,
-                            TransactionStatus.COLLECTED,
-                            TransactionStatus.GIVEAWAY_OFFERED,
-                            TransactionStatus.RETURN_REQUESTED,
-                            TransactionStatus.RETURN_ASSERTED,
-                            TransactionStatus.DISPUTED,
-                        ]
-                    )
+                    Q(item=self) & Q(status__in=BORROWER_TRANSACTION_STATUSES)
                 )
                 .order_by("-updated_at")
                 .first()
@@ -744,18 +718,7 @@ class Item(Model):
                     "party2",
                     "party2__profile",
                 )
-                .filter(
-                    Q(item=self)
-                    & ~Q(
-                        status__in=[
-                            TransactionStatus.RETURNED,
-                            TransactionStatus.REJECTED,
-                            TransactionStatus.CANCELLED,
-                            TransactionStatus.RESOLVED,
-                            TransactionStatus.OWNERSHIP_TRANSFERRED,
-                        ]
-                    )
-                )
+                .filter(Q(item=self) & ~Q(status__in=TERMINAL_TRANSACTION_STATUSES))
                 .order_by("-created_at")
                 .first()
             )
@@ -776,15 +739,7 @@ class Item(Model):
             return Transaction.objects.get(
                 Q(item=self)
                 & (Q(party1=user) | Q(party2=user))
-                & ~Q(
-                    status__in=[
-                        TransactionStatus.RETURNED,
-                        TransactionStatus.REJECTED,
-                        TransactionStatus.CANCELLED,
-                        TransactionStatus.RESOLVED,
-                        TransactionStatus.OWNERSHIP_TRANSFERRED,
-                    ]
-                )
+                & ~Q(status__in=TERMINAL_TRANSACTION_STATUSES)
             )
         except Transaction.DoesNotExist:
             return None
@@ -1199,6 +1154,36 @@ class TransactionStatus(IntegerChoices):
     CANCELLED = 80, "Cancelled"
     RESOLVED = 90, "Resolved"  # any force-resolved transaction, regardless of reason
     OWNERSHIP_TRANSFERRED = 95, "Ownership Transferred"
+
+
+# A transaction in one of these statuses is done; it no longer counts as the
+# item's current transaction.
+TERMINAL_TRANSACTION_STATUSES = (
+    TransactionStatus.RETURNED,
+    TransactionStatus.REJECTED,
+    TransactionStatus.CANCELLED,
+    TransactionStatus.RESOLVED,
+    TransactionStatus.OWNERSHIP_TRANSFERRED,
+)
+
+# A transaction in one of these statuses is an open borrow or giveaway
+# request awaiting the owner's decision.
+REQUEST_TRANSACTION_STATUSES = (
+    TransactionStatus.REQUESTED,
+    TransactionStatus.GIVEAWAY_REQUESTED,
+)
+
+# A transaction in one of these statuses has an assigned borrower (party2)
+# holding, or about to hold, the item.
+BORROWER_TRANSACTION_STATUSES = (
+    TransactionStatus.ACCEPTED,
+    TransactionStatus.COLLECTION_ASSERTED,
+    TransactionStatus.COLLECTED,
+    TransactionStatus.GIVEAWAY_OFFERED,
+    TransactionStatus.RETURN_REQUESTED,
+    TransactionStatus.RETURN_ASSERTED,
+    TransactionStatus.DISPUTED,
+)
 
 
 class ResolutionReason(TextChoices):

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -735,15 +735,16 @@ class Item(Model):
         Returns the transaction involving this item regardless of the user
         """
         try:
-            # Using `get()` here because if there *is* a current Active
-            # Transaction involving this Item , there should only be one.
-            # Related user data is loaded for card/status text rendering.
-            return Transaction.objects.select_related(
+        # Use `first()` so unexpected data issues (multiple non-terminal transactions)
+        # don't 500 the page; the most recent active transaction wins.
+        return (
+            Transaction.objects.select_related(
                 "party1",
                 "party1__profile",
                 "party2",
                 "party2__profile",
-            ).get(
+            )
+            .filter(
                 Q(item=self)
                 & ~Q(
                     status__in=[
@@ -755,8 +756,9 @@ class Item(Model):
                     ]
                 )
             )
-        except Transaction.DoesNotExist:
-            return None
+            .order_by("-created_at")
+            .first()
+        )
 
     def get_current_transaction_for_user(
         self, user: BorrowdUser

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -124,6 +124,22 @@ class PrecomputedItemState:
     current_transaction: Optional["Transaction"]
     has_active_subscription: bool = False
 
+    def current_transaction_for_user(
+        self, user: BorrowdUser
+    ) -> Optional["Transaction"]:
+        """
+        Returns current_transaction if the given user is a party to it,
+        mirroring what Item.get_current_transaction_for_user() would query.
+        """
+        if self.current_transaction is None:
+            return None
+        if (
+            self.current_transaction.party1_id == user.id
+            or self.current_transaction.party2_id == user.id
+        ):
+            return self.current_transaction
+        return None
+
 
 class ItemCategory(Model):
     name = CharField(max_length=50, null=False, blank=False)
@@ -274,15 +290,7 @@ class Item(Model):
         if precomputed is not None:
             current_borrower = precomputed.current_borrower
             requesting_user = precomputed.requesting_user
-            current_tx = (
-                precomputed.current_transaction
-                if precomputed.current_transaction
-                and (
-                    precomputed.current_transaction.party1_id == user.id
-                    or precomputed.current_transaction.party2_id == user.id
-                )
-                else None
-            )
+            current_tx = precomputed.current_transaction_for_user(user)
         else:
             current_borrower = self.get_current_borrower()
             requesting_user = self.get_requesting_user()
@@ -474,15 +482,7 @@ class Item(Model):
         # This may raise Transaction.MultipleObjectsReturned.
         # Let it propagate.
         if precomputed is not None:
-            current_tx = (
-                precomputed.current_transaction
-                if precomputed.current_transaction
-                and (
-                    precomputed.current_transaction.party1_id == user.id
-                    or precomputed.current_transaction.party2_id == user.id
-                )
-                else None
-            )
+            current_tx = precomputed.current_transaction_for_user(user)
             current_borrower = precomputed.current_borrower
             requesting_user = precomputed.requesting_user
             has_active_subscription = precomputed.has_active_subscription

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -735,25 +735,29 @@ class Item(Model):
         Returns the transaction involving this item regardless of the user
         """
         try:
-            # Using `get()` here because if there *is* a current Active
-            # Transaction involving this Item , there should only be one.
-            # Related user data is loaded for card/status text rendering.
-            return Transaction.objects.select_related(
-                "party1",
-                "party1__profile",
-                "party2",
-                "party2__profile",
-            ).get(
-                Q(item=self)
-                & ~Q(
-                    status__in=[
-                        TransactionStatus.RETURNED,
-                        TransactionStatus.REJECTED,
-                        TransactionStatus.CANCELLED,
-                        TransactionStatus.RESOLVED,
-                        TransactionStatus.OWNERSHIP_TRANSFERRED,
-                    ]
+            # Use `first()` so unexpected data issues (multiple non-terminal transactions)
+            # don't 500 the page; the most recent active transaction wins.
+            return (
+                Transaction.objects.select_related(
+                    "party1",
+                    "party1__profile",
+                    "party2",
+                    "party2__profile",
                 )
+                .filter(
+                    Q(item=self)
+                    & ~Q(
+                        status__in=[
+                            TransactionStatus.RETURNED,
+                            TransactionStatus.REJECTED,
+                            TransactionStatus.CANCELLED,
+                            TransactionStatus.RESOLVED,
+                            TransactionStatus.OWNERSHIP_TRANSFERRED,
+                        ]
+                    )
+                )
+                .order_by("-created_at")
+                .first()
             )
         except Transaction.DoesNotExist:
             return None

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -538,9 +538,8 @@ class Item(Model):
                 return (ItemAction.CANCEL_NOTIFICATION_REQUEST,)
 
             # At this point, either:
-            # - the user is the owner of the item (and thus can't request to borrow their
-            # no Request can be initiated.
-
+            # - the user is the owner of the item (and thus can't request to borrow it), or
+            # - the item is not borrowable and no notify/cancel-notify action applies.
             # NOTE Later we may want to allow new Requests on Items
             # even when they're currently Borrowed; that will
             # imply date-based borrowing bookings, which we're

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -735,16 +735,15 @@ class Item(Model):
         Returns the transaction involving this item regardless of the user
         """
         try:
-        # Use `first()` so unexpected data issues (multiple non-terminal transactions)
-        # don't 500 the page; the most recent active transaction wins.
-        return (
-            Transaction.objects.select_related(
+            # Using `get()` here because if there *is* a current Active
+            # Transaction involving this Item , there should only be one.
+            # Related user data is loaded for card/status text rendering.
+            return Transaction.objects.select_related(
                 "party1",
                 "party1__profile",
                 "party2",
                 "party2__profile",
-            )
-            .filter(
+            ).get(
                 Q(item=self)
                 & ~Q(
                     status__in=[
@@ -756,9 +755,8 @@ class Item(Model):
                     ]
                 )
             )
-            .order_by("-created_at")
-            .first()
-        )
+        except Transaction.DoesNotExist:
+            return None
 
     def get_current_transaction_for_user(
         self, user: BorrowdUser

--- a/borrowd_items/views.py
+++ b/borrowd_items/views.py
@@ -28,6 +28,7 @@ from borrowd_users.request import get_authenticated_user
 from .card_helpers import (
     build_item_card_context,
     build_item_cards_for_items,
+    with_card_relations,
 )
 from .exceptions import InvalidItemAction, ItemAlreadyRequested
 from .filters import ItemFilter
@@ -331,7 +332,7 @@ class ItemListView(
 
     def get_queryset(self) -> QuerySet[Item]:
         queryset: QuerySet[Item] = super().get_queryset()
-        return queryset.prefetch_related("photos")
+        return with_card_relations(queryset)
 
     def get_context_data(self, **kwargs: str) -> dict[str, Any]:
         context: dict[str, Any] = super().get_context_data(**kwargs)

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -26,6 +26,8 @@ from borrowd_groups.models import Membership
 from borrowd_items.card_helpers import (
     build_item_cards_for_items,
     build_item_cards_for_transactions,
+    with_card_relations,
+    with_card_relations_for_transactions,
 )
 from borrowd_items.models import Item, ItemStatus, Transaction
 from borrowd_notifications.models import NotificationPreference
@@ -258,9 +260,9 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
 
     # All transactions associated with the user with status == REQUESTED (awaiting approval from someone)
-    requested_transactions = Transaction.get_requested_status_transactions_for_user(
-        user
-    ).prefetch_related("item__photos")
+    requested_transactions = with_card_relations_for_transactions(
+        Transaction.get_requested_status_transactions_for_user(user)
+    )
 
     # these are requests FROM others TO this user - party1 is the item owner/lender
     incoming_borrow_requests = requested_transactions.filter(party1=user)
@@ -269,20 +271,20 @@ def inventory_view(request: HttpRequest) -> HttpResponse:
     outgoing_borrow_requests = requested_transactions.filter(party2=user)
 
     # User's items currently lent out (approved/accepted through return asserted)
-    owned_items_lent = Transaction.get_active_lends_for_user(user).prefetch_related(
-        "item__photos"
+    # Pre-fetch the required fields for the card context
+    owned_items_lent = with_card_relations_for_transactions(
+        Transaction.get_active_lends_for_user(user)
     )
 
     # Items the user is actively borrowing from others (accepted/approved through return asserted)
-    borrowed_items_from_others = Transaction.get_active_borrows_for_user(
-        user
-    ).prefetch_related("item__photos")
+    borrowed_items_from_others = with_card_relations_for_transactions(
+        Transaction.get_active_borrows_for_user(user)
+    )
 
     # User's items sitting idle with no active transaction.
-    owned_items_available = Item.objects.filter(
-        owner=user,
-        status=ItemStatus.AVAILABLE,
-    ).prefetch_related("photos")
+    owned_items_available = with_card_relations(
+        Item.objects.filter(owner=user, status=ItemStatus.AVAILABLE)
+    )
 
     # Build card context
     incoming_borrow_requests_cards = build_item_cards_for_transactions(


### PR DESCRIPTION
## Summary                                                                                       
Fixes the `/profile/inventory/` page N+1 issue confirmed in #531: rendering item cards was issuing ~14 duplicate/redundant queries per item (re-querying `current borrower/requester/transaction` independently in multiple code paths, plus a `.first()` call that silently bypassed prefetching). This also directly explains why the e2e item-deletion sweep and item-creation flow were slow, since both redirect to this same page. Query cost is now a small flat overhead per section plus ~2 queries per item, regardless of how many items are in the account.                                  

## Linked Issue(s)
Closes #531                                                                                      

## Type of Change
- [ ] Bug fix
- [x] Refactor / cleanup
- [ ] New feature
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
- `borrowd_items/models.py` — Added `PrecomputedItemState` (current_borrower/requesting_user/current_transaction/has_active_subscription) and a new item-scoped `Item.get_current_transaction()`, unifying three previously-different "what's this item's active transaction" queries into one verified-equivalent definition. `get_action_context_for()`/`get_actions_for()`/`_get_status_text_for_user()`/`_get_other_user_status_text()` now accept an optional `precomputed` bundle instead of each independently re-querying `get_current_borrower()`/`get_requesting_user()`/`get_current_transaction_for_user()`. Comparisons like `self.owner == user` were switched to `self.owner_id == user.id` (and similarly for `party1`/`party2`/`updated_by`) to avoid resolving FK objects just to compare identity.
- `borrowd_items/card_helpers.py` — Added batch precompute functions (`_precompute_item_states_for_items`, `_precompute_item_states_for_transactions`, `_precompute_item_state`) that derive card state for an entire section with one `Transaction` query and one `AvailabilitySubscription` query, instead of per-item lookups. Added `with_card_relations()` / `with_card_relations_for_transactions()` — queryset decorators callers apply before evaluating their queryset, so `select_related`/`prefetch_related` is set up correctly at the source . Fixed `item.photos.first()` (bypassed the applied `prefetch_related`) to `next(iter(item.photos.all()), None)`.
- `borrowd_users/views.py` (`inventory_view`) — All 5 section querysets now wrapped with `with_card_relations()`/`with_card_relations_for_transactions()`.
- `borrowd_items/views.py` (`ItemListView`, search results) — `get_queryset()` now uses `with_card_relations()` instead of a bare `.prefetch_related("photos")`.

## How to Test
1. `uv run manage.py test` — full suite (394 tests) pass unchanged; no behavior change intended.
2. Log in as a user with a non-trivial inventory (items across owned/lent/borrowed/requested), load `/profile/inventory/`, and confirm all sections, banners, and action buttons render identically to before.
3. Optional scale check: with Django Debug Toolbar or `django.test.utils.CaptureQueriesContext`, confirm inventory page query count stays flat-ish as item count grows (roughly 2 queries/item) instead of scaling at ~14/item.
4. Exercise the search page (`/items/?search=...`) to confirm item cards there are unaffected (same `build_item_cards_for_items` path, now via `with_card_relations`).

## Screenshots (if UI change)
Not applicable; no visual UI change

## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [x] I have checked this works for r members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
Verification for this PR was done with local scripts (query capture + timing), not committed. Existing behavioral tests (`test_card_helpers.py`, borrowing/return/giveaway flow tests, etc.) all pass unchanged, which confirms the refactor doesn't affect the behaviour correctness.

The main behavior of `get_current_transaction()`'s exclusion-based status filters (`_TERMINAL_TRANSACTION_STATUSES`) is relied on to be equivalent to the old **inclusion-based** filter: verified by enumerating the full `TransactionStatus` set and excluding the non-terminal statuses:  **worth a second look**. 
Also relies on the existing app-level invariant of at most one non-terminal `Transaction` per item at a time. 