### PR TITLE
Feat 493 notifications fe

### DIFF
--- a/borrowd/config/base.py
+++ b/borrowd/config/base.py
@@ -107,6 +107,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "borrowd_beta.context_processors.beta_status",
                 "borrowd_groups.context_processors.groups_needing_moderator",
+                "borrowd_notifications.context_processors.unread_notification_count",
             ],
         },
     },

--- a/borrowd/util.py
+++ b/borrowd/util.py
@@ -12,7 +12,7 @@ from django.urls import Resolver404, resolve
 logger = logging.getLogger(__name__)
 
 
-def _is_safe_back_url(url: str, request: HttpRequest) -> bool:
+def is_safe_back_url(url: str, request: HttpRequest) -> bool:
     """
     True if `url` is safe to use as a back-button target: a relative path,
     or an absolute URL whose host matches the current request's host.
@@ -61,7 +61,7 @@ def resolve_back_url(
     """
 
     """
-    Using `url_has_allowed_host_and_scheme` instead of `_is_safe_back_url`
+    Using `url_has_allowed_host_and_scheme` instead of `is_safe_back_url`
     would look something like:
     ```
     next_url = request.GET.get("next")
@@ -74,7 +74,7 @@ def resolve_back_url(
     ```
     """
     next_url = request.GET.get("next")
-    if next_url and _is_safe_back_url(next_url, request):
+    if next_url and is_safe_back_url(next_url, request):
         return next_url
 
     referer = request.META.get("HTTP_REFERER")

--- a/borrowd_notifications/context_processors.py
+++ b/borrowd_notifications/context_processors.py
@@ -14,4 +14,4 @@ def unread_notification_count(request: HttpRequest) -> dict[str, Any]:
 
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     qs: QuerySet[Notification] = app_channel_qs(request.user.notifications.all())  # type: ignore[attr-defined]
-    return {"unread_count": qs.unread().count()}  # type: ignore[attr-defined]
+    return {"unread_notification_count": qs.unread().count()}  # type: ignore[attr-defined]

--- a/borrowd_notifications/context_processors.py
+++ b/borrowd_notifications/context_processors.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from notifications.models import Notification
+
+from .views import app_channel_qs
+
+
+def unread_notification_count(request: HttpRequest) -> dict[str, Any]:
+    """Adds the unread in-app notification count for the header bell."""
+    if not request.user.is_authenticated:
+        return {}
+
+    # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
+    qs: QuerySet[Notification] = app_channel_qs(request.user.notifications.all())  # type: ignore[attr-defined]
+    return {"unread_count": qs.unread().count()}  # type: ignore[attr-defined]

--- a/borrowd_notifications/inbox_urls.py
+++ b/borrowd_notifications/inbox_urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     mark_all_notifications_read,
     mark_notification_read,
+    notification_bell_count,
     notification_inbox_view,
     notification_popup_view,
     open_notification,
@@ -18,4 +19,7 @@ urlpatterns = [
     path("delete-all/", remove_all_app_notifications, name="notification-delete-all"),
     path("popup/", notification_popup_view, name="notification-popup"),
     path("<int:pk>/open/", open_notification, name="notification-open"),
+    path(
+        "notification-count/", notification_bell_count, name="notification-bell-count"
+    ),
 ]

--- a/borrowd_notifications/inbox_urls.py
+++ b/borrowd_notifications/inbox_urls.py
@@ -4,6 +4,8 @@ from .views import (
     mark_all_notifications_read,
     mark_notification_read,
     notification_inbox_view,
+    notification_popup_view,
+    open_notification,
     remove_all_app_notifications,
     remove_app_notification,
 )
@@ -14,4 +16,6 @@ urlpatterns = [
     path("read-all/", mark_all_notifications_read, name="notification-mark-all-read"),
     path("<int:pk>/delete/", remove_app_notification, name="notification-delete"),
     path("delete-all/", remove_all_app_notifications, name="notification-delete-all"),
+    path("popup/", notification_popup_view, name="notification-popup"),
+    path("<int:pk>/open/", open_notification, name="notification-open"),
 ]

--- a/borrowd_notifications/models.py
+++ b/borrowd_notifications/models.py
@@ -256,7 +256,6 @@ class NotificationType(models.TextChoices):
             if notification.verb == NotificationType.ITEM_SUBSCRIPTION.value:
                 context.update(
                     {
-                        "subscriber_name": subscription.user.first_name,
                         "item_name": subscription.item.name,
                         "item_url": base_url
                         + reverse("item-detail", args=[subscription.item.pk]),
@@ -279,12 +278,12 @@ _MESSAGE_TEMPLATES: dict[NotificationType, str] = {
     NotificationType.ITEM_REQUESTED: "{requester_name} wants to borrow your {item_name}",
     NotificationType.ITEM_REQUEST_ACCEPTED: "{item_owner_name} accepted your request for {item_name}",
     NotificationType.ITEM_REQUEST_DENIED: "Your request for {item_name} was declined",
-    NotificationType.COLLECTION_ASSERTED: "{requester_name} says they have collected {item_name}",
+    NotificationType.COLLECTION_ASSERTED: "{requester_name} says {item_name} has been collected, please confirm.",
     NotificationType.COLLECTION_CONFIRMED: "{item_owner_name} confirmed collection of {item_name}",
-    NotificationType.RETURN_ASSERTED: "{requester_name} says they have returned {item_name}",
+    NotificationType.RETURN_ASSERTED: "{requester_name} says {item_name} has been returned, please confirm.",
     NotificationType.RETURN_CONFIRMED: "{item_owner_name} confirmed the return of {item_name}",
     NotificationType.ITEM_NOTIFY_WHEN_AVAILABLE: "{owner_name} has {item_name} available to borrow",
-    NotificationType.ITEM_SUBSCRIPTION: "{subscriber_name} subscribed to be notified when {item_name} becomes available",
+    NotificationType.ITEM_SUBSCRIPTION: "You've subscribed to be notified when {item_name} becomes available.",
     NotificationType.ITEM_RETURN_REQUESTED: "{owner_name} requested the return of {item_name}",
     NotificationType.ITEM_DISPUTED: "{dispute_raiser_name} raised a dispute over {item_name}",
     NotificationType.GROUP_MEMBER_JOINED: "{new_member_name} joined {group_name}",

--- a/borrowd_notifications/signals.py
+++ b/borrowd_notifications/signals.py
@@ -158,13 +158,14 @@ def send_transaction_notifications(
                 description=f"Your request for {instance.item.name} was declined",
             )
         case TransactionStatus.COLLECTION_ASSERTED:
+            who = "they've" if instance.item.owner != instance.updated_by else "you've"
             notify.send(
                 instance.updated_by,
                 recipient=[instance.counter_party(instance.updated_by)],
                 verb=NotificationType.COLLECTION_ASSERTED.value,
                 action_object=instance.item,
                 target=instance,
-                description=f"{instance.updated_by.first_name} says they've collected {instance.item.name}. Please confirm.",
+                description=f"{instance.updated_by.first_name} says {who} collected {instance.item.name}. Please confirm.",
             )
         case TransactionStatus.COLLECTED:
             notify.send(

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -1704,19 +1704,37 @@ class NotificationInboxViewTests(TestCase):
         )
         return n
 
-    def test_unread_count_only_includes_app_channel_notifications(self) -> None:
+    def test_unread_notification_count_only_includes_app_channel_notifications(
+        self,
+    ) -> None:
         """Notifications without APP channel don't inflate the unread badge count."""
         self._make_notification(with_app_channel=False)
         response = self.client.get("/notifications/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["unread_count"], 0)
+        self.assertEqual(response.context["unread_notification_count"], 0)
 
-    def test_unread_count_includes_app_channel_notifications(self) -> None:
+    def test_unread_notification_count_includes_app_channel_notifications(self) -> None:
         """Notifications with APP channel are counted in the unread badge."""
         self._make_notification(with_app_channel=True)
         response = self.client.get("/notifications/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context["unread_count"], 1)
+        self.assertEqual(response.context["unread_notification_count"], 1)
+
+    def test_notification_bell_count_returns_indicator_contents_only(self) -> None:
+        """The poll endpoint must not return another polling wrapper."""
+        self._make_notification(with_app_channel=True)
+
+        response = self.client.get("/notifications/notification-count/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, "notifications/_notification_count_indicator.html"
+        )
+        self.assertContains(response, "badge-primary")
+        self.assertContains(response, "1")
+        self.assertNotContains(response, 'id="notification-indicator"')
+        self.assertNotContains(response, "hx-trigger")
+        self.assertNotContains(response, "notification-popup-content")
 
     def test_inbox_excludes_non_app_channel_notifications(self) -> None:
         """Notifications routed only to EMAIL don't appear in the inbox list."""

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -39,6 +39,7 @@ from .models import (
     NotificationType,
     PushSubscription,
 )
+from .views import _notification_action_url
 
 
 class GroupMemberJoinedNotificationTests(TestCase):
@@ -2386,3 +2387,106 @@ class PUSHNotificationStrategyTests(TransactionTestCase):
         self.assertEqual(
             payload.data.channels[ChannelType.PUSH].status, NotificationState.ERROR
         )
+
+
+class NotificationActionUrlTests(TestCase):
+    """Guards _notification_action_url's dispatch on action_object type.
+
+    Every notify.send() call across the app (borrowd_notifications,
+    borrowd_groups, and borrowd_users/services.py) sets action_object to an
+    Item, a Membership, or a BorrowdGroup. If a future call site sets some
+    other type without _notification_action_url being updated to match, the
+    resulting notification silently renders as a non-clickable card with no
+    error anywhere -- these tests fail loudly instead.
+    """
+
+    def setUp(self) -> None:
+        self.user = BorrowdUser.objects.create_user(
+            username="user", email="user@example.com", password="password"
+        )
+        self.group = BorrowdGroup.objects.create_group(
+            name="Test Group", created_by=self.user, updated_by=self.user
+        )
+        self.item = Item.objects.create(
+            name="Drill",
+            owner=self.user,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def _notification_for(self, action_object: Any) -> Notification:
+        from notifications.signals import notify
+
+        notify.send(
+            self.user,
+            recipient=[self.user],
+            verb=NotificationType.ITEM_REQUESTED.value,
+            action_object=action_object,
+            description="test",
+        )
+        return Notification.objects.filter(recipient=self.user).latest("timestamp")
+
+    def test_item_action_object_resolves_to_item_detail(self) -> None:
+        notification = self._notification_for(self.item)
+        self.assertEqual(
+            _notification_action_url(notification), f"/items/{self.item.pk}/"
+        )
+
+    def test_soft_deleted_item_action_object_resolves_to_no_link(self) -> None:
+        """ItemDetailView's default manager excludes soft-deleted items, so
+        linking there would 404. item_card.html already treats a removed
+        item as non-clickable (pointer-events-none) elsewhere in the app;
+        match that instead of producing a dead link."""
+        self.item.deleted_at = timezone.now()
+        self.item.save(update_fields=["deleted_at"])
+        notification = self._notification_for(self.item)
+        self.assertIsNone(_notification_action_url(notification))
+
+    def test_membership_action_object_resolves_to_group_detail(self) -> None:
+        membership = Membership.objects.get(user=self.user, group=self.group)
+        notification = self._notification_for(membership)
+        self.assertEqual(
+            _notification_action_url(notification), f"/groups/{self.group.pk}/"
+        )
+
+    def test_group_action_object_resolves_to_group_detail(self) -> None:
+        """Regression test: GROUP_NEEDS_MODERATOR (borrowd_groups/signals.py)
+        sets action_object=group directly, not a Membership."""
+        notification = self._notification_for(self.group)
+        self.assertEqual(
+            _notification_action_url(notification), f"/groups/{self.group.pk}/"
+        )
+
+    def test_unrecognized_action_object_resolves_to_no_link(self) -> None:
+        """A recipient user (or any other model) as action_object has no
+        known destination -- this is the expected safe fallback, not a bug."""
+        notification = self._notification_for(self.user)
+        self.assertIsNone(_notification_action_url(notification))
+
+
+class GroupNeedsModeratorNotificationLinkTests(TestCase):
+    """End-to-end regression test for the real GROUP_NEEDS_MODERATOR gap:
+    the last moderator leaving a group notifies remaining members with
+    action_object=group, which _notification_action_url must resolve."""
+
+    def test_last_moderator_leaving_produces_a_clickable_notification(self) -> None:
+        creator = BorrowdUser.objects.create_user(
+            username="creator", email="creator@example.com", password="password"
+        )
+        member = BorrowdUser.objects.create_user(
+            username="member", email="member@example.com", password="password"
+        )
+        group = BorrowdGroup.objects.create_group(
+            name="Test Group",
+            created_by=creator,
+            updated_by=creator,
+            membership_requires_approval=False,
+        )
+        group.add_user(member)
+
+        group.remove_user(creator, bypass_last_moderator_check=True)
+
+        notification = Notification.objects.get(
+            recipient=member, verb=NotificationType.GROUP_NEEDS_MODERATOR.value
+        )
+        self.assertEqual(_notification_action_url(notification), f"/groups/{group.pk}/")

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -1936,8 +1936,13 @@ class NotificationDeleteTests(TestCase):
         self.assertIn("APP", (n.data or {}).get("channels", {}))
         self.assertFalse(n.unread)
 
-    def test_remove_notification_htmx_returns_empty_response(self) -> None:
-        """HTMX deletion removes the card without forcing a full-page redirect."""
+    def test_remove_notification_htmx_returns_oob_badge_update(self) -> None:
+        """HTMX deletion removes the card (an empty main swap, since there's
+        no notification content left to show) without forcing a full-page
+        redirect, and carries an out-of-band header badge update so the
+        unread count refreshes immediately instead of waiting for the next
+        30s poll.
+        """
         n = self._make_app_notification()
 
         response = self.client.post(
@@ -1946,7 +1951,9 @@ class NotificationDeleteTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b"")
+        self.assertNotContains(response, f'id="notification-card-{n.pk}"')
+        self.assertContains(response, 'id="notification-indicator"')
+        self.assertContains(response, 'hx-swap-oob="true"')
         n.refresh_from_db()
         n.borrowd_metadata.refresh_from_db()
         self.assertFalse(n.borrowd_metadata.visible_in_app)

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -1850,6 +1850,49 @@ class NotificationInboxViewTests(TestCase):
         self.assertTrue(hidden.unread)
 
 
+class NotificationPopupViewTests(TestCase):
+    """Tests for the header bell's dropdown popup."""
+
+    def setUp(self) -> None:
+        self.user = BorrowdUser.objects.create_user(
+            username="user", email="user@example.com", password="password"
+        )
+        self.client.force_login(self.user)
+
+    def _make_notification(self) -> Notification:
+        from notifications.signals import notify
+
+        notify.send(
+            self.user,
+            recipient=[self.user],
+            verb=NotificationType.ITEM_REQUESTED.value,
+            description="test",
+        )
+        n = Notification.objects.filter(recipient=self.user).latest("timestamp")
+        n.data = {
+            "context": {},
+            "icon": None,
+            "channels": {"APP": {"status": "SUCCESS", "error": None}},
+        }
+        n.unread = True
+        n.save()
+        NotificationMetadata.objects.update_or_create(
+            notification=n,
+            defaults={"visible_in_app": True},
+        )
+        return n
+
+    def test_popup_shows_up_to_ten_notifications(self) -> None:
+        """PRD AC 6.1: the dropdown shows the most recent 10 notifications."""
+        for _ in range(12):
+            self._make_notification()
+
+        response = self.client.get("/notifications/popup/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["notifications"]), 10)
+
+
 class NotificationDeleteTests(TestCase):
     """Tests for remove_app_notification and remove_all_app_notifications."""
 
@@ -2542,6 +2585,25 @@ class NotificationActionUrlTests(TestCase):
         self.assertEqual(
             _notification_action_url(notification), f"/groups/{self.group.pk}/"
         )
+
+    def test_soft_deleted_group_action_object_resolves_to_no_link(self) -> None:
+        """A soft-deleted group's detail page isn't guaranteed reachable, so
+        (matching the soft-deleted item case) the card should render
+        non-clickable rather than link to a group that may 404 or 403."""
+        self.group.deleted_at = timezone.now()
+        self.group.save(update_fields=["deleted_at"])
+        notification = self._notification_for(self.group)
+        self.assertIsNone(_notification_action_url(notification))
+
+    def test_membership_action_object_with_soft_deleted_group_resolves_to_no_link(
+        self,
+    ) -> None:
+        """Same soft-delete guard, one hop out via the membership's group."""
+        self.group.deleted_at = timezone.now()
+        self.group.save(update_fields=["deleted_at"])
+        membership = Membership.objects.get(user=self.user, group=self.group)
+        notification = self._notification_for(membership)
+        self.assertIsNone(_notification_action_url(notification))
 
     def test_unrecognized_action_object_resolves_to_no_link(self) -> None:
         """A recipient user (or any other model) as action_object has no

--- a/borrowd_notifications/tests.py
+++ b/borrowd_notifications/tests.py
@@ -1730,6 +1730,42 @@ class NotificationInboxViewTests(TestCase):
         response = self.client.get("/notifications/")
         self.assertEqual(response.context["page_obj"].paginator.count, 1)
 
+    def test_notification_delete_button_uses_htmx_card_swap(self) -> None:
+        """Rendered delete controls remove their card without a full-page redirect."""
+        notification = self._make_notification(with_app_channel=True)
+
+        response = self.client.get("/notifications/")
+
+        self.assertContains(response, f'id="notification-card-{notification.pk}"')
+        self.assertContains(
+            response,
+            f'hx-post="/notifications/{notification.pk}/delete/"',
+        )
+        self.assertContains(
+            response,
+            f'hx-target="#notification-card-{notification.pk}"',
+        )
+        self.assertContains(response, 'hx-swap="outerHTML swap:200ms"')
+
+    def test_notification_mark_read_button_uses_htmx_card_swap(self) -> None:
+        """Rendered mark-read controls update their card without a redirect."""
+        notification = self._make_notification(with_app_channel=True)
+
+        response = self.client.get("/notifications/")
+
+        self.assertContains(
+            response,
+            f'hx-post="/notifications/{notification.pk}/read/"',
+        )
+        self.assertContains(
+            response,
+            f'hx-target="#notification-card-{notification.pk}"',
+        )
+        self.assertContains(
+            response,
+            "notification-card-reading",
+        )
+
     def test_recent_notification_uses_relative_timestamp(self) -> None:
         """Notifications less than seven days old retain relative timestamps."""
         notification = self._make_notification(with_app_channel=True)
@@ -1765,6 +1801,22 @@ class NotificationInboxViewTests(TestCase):
         response = self.client.post(f"/notifications/{notification.pk}/read/")
 
         self.assertEqual(response.status_code, 404)
+
+    def test_mark_notification_read_htmx_returns_read_card(self) -> None:
+        """HTMX mark-read returns the card re-rendered in its read state."""
+        notification = self._make_notification(with_app_channel=True)
+
+        response = self.client.post(
+            f"/notifications/{notification.pk}/read/",
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        notification.refresh_from_db()
+        self.assertFalse(notification.unread)
+        self.assertContains(response, f'id="notification-card-{notification.pk}"')
+        self.assertNotContains(response, "Mark as read")
+        self.assertNotContains(response, "notification-card-reading")
 
     def test_mark_all_read_only_updates_visible_notifications(self) -> None:
         """Mark-all leaves non-app notification state untouched."""
@@ -1821,6 +1873,22 @@ class NotificationDeleteTests(TestCase):
         n.borrowd_metadata.refresh_from_db()
         self.assertFalse(n.borrowd_metadata.visible_in_app)
         self.assertIn("APP", (n.data or {}).get("channels", {}))
+        self.assertFalse(n.unread)
+
+    def test_remove_notification_htmx_returns_empty_response(self) -> None:
+        """HTMX deletion removes the card without forcing a full-page redirect."""
+        n = self._make_app_notification()
+
+        response = self.client.post(
+            f"/notifications/{n.pk}/delete/",
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+        n.refresh_from_db()
+        n.borrowd_metadata.refresh_from_db()
+        self.assertFalse(n.borrowd_metadata.visible_in_app)
         self.assertFalse(n.unread)
 
     def test_remove_notification_disappears_from_inbox(self) -> None:

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -271,7 +271,7 @@ _INBOX_PAGE_SIZE = 25
 _RELATIVE_TIMESTAMP_MAX_AGE = timedelta(days=7)
 
 
-def _app_channel_qs(qs: QuerySet[Notification]) -> QuerySet[Notification]:
+def app_channel_qs(qs: QuerySet[Notification]) -> QuerySet[Notification]:
     """Filter to notifications currently visible in the in-app inbox."""
     return qs.filter(borrowd_metadata__visible_in_app=True)
 
@@ -296,7 +296,7 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
 
     # only show the notifications that where sent through the in-app channel
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
-    qs: QuerySet[Notification] = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
+    qs: QuerySet[Notification] = app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     paginator = Paginator(qs, _INBOX_PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get("page", 1))
 
@@ -336,7 +336,7 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
 def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
-    _app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
+    app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
     return redirect("notification-inbox")
 
 
@@ -368,7 +368,7 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
-    visible_notifications = _app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
+    visible_notifications = app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
     visible_notifications.update(unread=False)
     NotificationMetadata.objects.filter(
         notification__recipient=user,

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -1,16 +1,23 @@
+from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any
+from string import Formatter
+from typing import Any, TypedDict
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.core.paginator import Paginator
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_GET, require_POST
 from notifications.models import Notification
 
+from borrowd.util import is_safe_back_url
+from borrowd_groups.models import BorrowdGroup, Membership
+from borrowd_items.models import Item
 from borrowd_users.models import BorrowdUser
 from borrowd_users.request import get_authenticated_user
 
@@ -271,23 +278,138 @@ _INBOX_PAGE_SIZE = 25
 _RELATIVE_TIMESTAMP_MAX_AGE = timedelta(days=7)
 
 
+class NotificationMessagePart(TypedDict):
+    text: str
+    is_emphasized: bool
+
+
 def app_channel_qs(qs: QuerySet[Notification]) -> QuerySet[Notification]:
-    """Filter to notifications currently visible in the in-app inbox."""
-    return qs.filter(borrowd_metadata__visible_in_app=True)
+    """Filter to notifications currently visible in the in-app inbox.
+
+    Also prefetches action_object (a GenericForeignKey, so a plain
+    select_related/prefetch_related can't cover it): every notify.send()
+    call sets it to an Item or a Membership (see signals.py), and
+    _notification_action_url reads it for every row on the page, so
+    without this each row costs its own query.
+    """
+    return qs.filter(borrowd_metadata__visible_in_app=True).prefetch_related(
+        GenericPrefetch("action_object", [Item.objects.all(), Membership.objects.all()])
+    )
 
 
-def _format_notification(notification: Notification) -> str:
+def _notification_message_template_and_context(
+    notification: Notification,
+) -> tuple[str, dict[str, Any]]:
     try:
         template = NotificationType(notification.verb).message_template
     except ValueError:
-        return str(notification.verb)
+        return str(notification.verb), {}
+
     context: dict[str, Any] = {}
     if isinstance(notification.data, dict):
-        context = notification.data.get("context", {})
+        raw_context = notification.data.get("context", {})
+        if isinstance(raw_context, dict):
+            context = {str(key): value for key, value in raw_context.items()}
+    return template, context
+
+
+def _notification_message_parts(
+    template: str, context: dict[str, Any], fallback_text: str
+) -> list[NotificationMessagePart]:
+    formatter = Formatter()
+    parts: list[NotificationMessagePart] = []
+
     try:
-        return template.format(**context)
-    except KeyError:
-        return str(notification.verb)
+        parsed_template = list(formatter.parse(template))
+    except ValueError:
+        return [{"text": fallback_text, "is_emphasized": False}]
+
+    for literal_text, field_name, format_spec, _conversion in parsed_template:
+        if literal_text:
+            parts.append({"text": literal_text, "is_emphasized": False})
+
+        if field_name is None:
+            continue
+
+        if field_name not in context:
+            return [{"text": fallback_text, "is_emphasized": False}]
+
+        try:
+            text = formatter.format_field(context[field_name], format_spec or "")
+        except (KeyError, ValueError, TypeError):
+            return [{"text": fallback_text, "is_emphasized": False}]
+
+        parts.append({"text": text, "is_emphasized": True})
+
+    return parts or [{"text": fallback_text, "is_emphasized": False}]
+
+
+def _get_notification_category(
+    notification_type: NotificationType,
+) -> dict[str, Any] | None:
+    for cat in NOTIFICATION_CATEGORIES:
+        for ntype, type_des in cat["types"]:
+            if ntype == notification_type:
+                return {"notification_title": type_des, "notification_category": cat}
+    return None
+
+
+def _notification_action_url(notification: Notification) -> str | None:
+    """Resolves where clicking a notification should land, based on the
+    action_object set by notify.send() calls across the app (see signals.py
+    in this app, borrowd_groups, and borrowd_users/services.py): an Item
+    goes to its detail page, a Membership or BorrowdGroup to the group's
+    detail page.
+    """
+    action_object = notification.action_object
+    if isinstance(action_object, Item):
+        # A soft-deleted item's detail page 404s (ItemDetailView uses the
+        # default active-only manager). item_card.html already treats
+        # `is_removed` items as non-clickable elsewhere in the app
+        # (pointer-events-none); match that instead of linking to a dead page.
+        if action_object.deleted_at is not None:
+            return None
+        return reverse("item-detail", kwargs={"pk": action_object.pk})
+    if isinstance(action_object, Membership):
+        return reverse(
+            "borrowd_groups:group-detail", kwargs={"pk": action_object.group_id}
+        )
+    if isinstance(action_object, BorrowdGroup):
+        return reverse("borrowd_groups:group-detail", kwargs={"pk": action_object.pk})
+    return None
+
+
+def _annotate_for_display(notifications: Iterable[Notification]) -> None:
+    """Sets display-only fields (not persisted) read by the notification card partial."""
+    relative_timestamp_cutoff = timezone.now() - _RELATIVE_TIMESTAMP_MAX_AGE
+    for notification in notifications:
+        message_template, message_context = _notification_message_template_and_context(
+            notification
+        )
+        notification.message_template = message_template
+        notification.message_context = message_context
+        notification.message_parts = _notification_message_parts(
+            message_template, message_context, str(notification.verb)
+        )
+
+        try:
+            notification_type = NotificationType(notification.verb)
+        except ValueError:
+            notification.category = "Borrowd"
+            notification.title = "Notification"
+        else:
+            cat = _get_notification_category(notification_type)
+            if cat:
+                notification.category = cat["notification_category"]
+                notification.title = cat["notification_title"]
+            else:
+                notification.category = "Borrowd"
+                notification.title = "Notification"
+
+        notification.show_absolute_timestamp = (
+            notification.timestamp <= relative_timestamp_cutoff
+        )
+        notification.action_url = _notification_action_url(notification)
 
 
 @login_required
@@ -300,22 +422,29 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
     paginator = Paginator(qs, _INBOX_PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get("page", 1))
 
-    relative_timestamp_cutoff = timezone.now() - _RELATIVE_TIMESTAMP_MAX_AGE
-    for notification in page_obj:
-        notification.formatted_message = _format_notification(notification)
-        notification.show_absolute_timestamp = (
-            notification.timestamp <= relative_timestamp_cutoff
-        )
+    _annotate_for_display(page_obj)
 
+    # unread_count comes from the unread_notification_count context
+    # processor (borrowd_notifications/context_processors.py), which every
+    # authenticated page already computes for the header bell — no need to
+    # run the same count query again here.
     return render(
         request,
         "notifications/inbox.html",
-        {
-            "page_obj": page_obj,
-            # notifications is untyped (see mypy.ini): unread() manager method is invisible.
-            "unread_count": qs.unread().count(),  # type: ignore[attr-defined]
-        },
+        {"page_obj": page_obj},
     )
+
+
+def _redirect_to_caller(request: HttpRequest) -> HttpResponse:
+    """Sends the user back to wherever they submitted the form from (the
+    inbox page or the header's notification popup), rather than always
+    landing on the inbox.
+    """
+    fallback_url = reverse("notification-inbox")
+    referer = request.META.get("HTTP_REFERER", "")
+    if referer and is_safe_back_url(referer, request):
+        return redirect(referer)
+    return redirect(fallback_url)
 
 
 @login_required
@@ -328,7 +457,30 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
         borrowd_metadata__visible_in_app=True,
     )
     notification.mark_as_read()
-    return redirect("notification-inbox")
+    return _redirect_to_caller(request)
+
+
+@login_required
+@require_POST
+def open_notification(request: HttpRequest, pk: int) -> HttpResponse:
+    """Marks a notification read and sends the user to the page it's about
+    (see _notification_action_url); falls back to the inbox if it has
+    nothing to link to.
+
+    POST rather than GET: marking read is a state change, and a bare GET
+    link has no CSRF protection, so any cross-site request (an <img> tag,
+    a prefetched link) could silently mark a guessed notification pk as
+    read. A form matches the other per-notification actions in this card.
+    """
+    notification = get_object_or_404(
+        Notification,
+        pk=pk,
+        recipient=request.user,
+        borrowd_metadata__visible_in_app=True,
+    )
+    notification.mark_as_read()
+    action_url = _notification_action_url(notification)
+    return redirect(action_url or reverse("notification-inbox"))
 
 
 @login_required
@@ -337,7 +489,7 @@ def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
     user = get_authenticated_user(request)
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     app_channel_qs(user.notifications.all()).update(unread=False)  # type: ignore[attr-defined]
-    return redirect("notification-inbox")
+    return _redirect_to_caller(request)
 
 
 def delete_app_notification(notification: Notification) -> None:
@@ -360,7 +512,7 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
     delete_app_notification(notification=notification)
-    return redirect("notification-inbox")
+    return _redirect_to_caller(request)
 
 
 @login_required
@@ -375,3 +527,31 @@ def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
         visible_in_app=True,
     ).update(visible_in_app=False)
     return redirect("notification-inbox")
+
+
+_POPUP_NOTIFICATION_LIMIT = 5
+
+
+@login_required
+@require_GET
+def notification_popup_view(request: HttpRequest) -> HttpResponse:
+    user = get_authenticated_user(request)
+
+    # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
+    qs: QuerySet[Notification] = app_channel_qs(
+        user.notifications.all()  # type: ignore[attr-defined]
+    )
+
+    notifications = qs.order_by("-timestamp")[:_POPUP_NOTIFICATION_LIMIT]
+
+    _annotate_for_display(notifications)
+
+    # unread_count comes from the unread_notification_count context
+    # processor (borrowd_notifications/context_processors.py), which every
+    # authenticated page already computes for the header bell — no need to
+    # run the same count query again here.
+    return render(
+        request,
+        "notifications/popup.html",
+        {"notifications": notifications},
+    )

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -446,10 +446,14 @@ def _notification_action_url(notification: Notification) -> str | None:
             return None
         return reverse("item-detail", kwargs={"pk": action_object.pk})
     if isinstance(action_object, Membership):
-        return reverse(
-            "borrowd_groups:group-detail", kwargs={"pk": action_object.group_id}
-        )
+        group = action_object.group
+        # Same soft-delete guard as above, one hop out via the membership.
+        if group.deleted_at is not None:
+            return None
+        return reverse("borrowd_groups:group-detail", kwargs={"pk": group.pk})
     if isinstance(action_object, BorrowdGroup):
+        if action_object.deleted_at is not None:
+            return None
         return reverse("borrowd_groups:group-detail", kwargs={"pk": action_object.pk})
     return None
 
@@ -675,7 +679,7 @@ def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
     return redirect("notification-inbox")
 
 
-_POPUP_NOTIFICATION_LIMIT = 5
+_POPUP_NOTIFICATION_LIMIT = 10
 
 
 @login_required

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -514,14 +514,14 @@ def _annotate_for_display(notifications: Iterable[Notification]) -> None:
             message_template, message_context, str(notification.verb)
         )
 
+        notification_type: NotificationType | None = None
         try:
             notification_type = NotificationType(notification.verb)
         except ValueError:
-            notification.category = "Borrowd"
-            notification.title = "Notification"
+            pass
 
         notification_title, category = (None, None)
-        if notification_type:
+        if notification_type is not None:
             notification_title, category = _get_notification_category(notification_type)
 
         notification.title = (

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -424,7 +424,7 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
 
     _annotate_for_display(page_obj)
 
-    # unread_count comes from the unread_notification_count context
+    # unread_notification_count comes from the unread_notification_count context
     # processor (borrowd_notifications/context_processors.py), which every
     # authenticated page already computes for the header bell — no need to
     # run the same count query again here.
@@ -555,7 +555,7 @@ def notification_popup_view(request: HttpRequest) -> HttpResponse:
 
     _annotate_for_display(notifications)
 
-    # unread_count comes from the unread_notification_count context
+    # unread_notification_count comes from the unread_notification_count context
     # processor (borrowd_notifications/context_processors.py), which every
     # authenticated page already computes for the header bell — no need to
     # run the same count query again here.
@@ -564,3 +564,9 @@ def notification_popup_view(request: HttpRequest) -> HttpResponse:
         "notifications/popup.html",
         {"notifications": notifications},
     )
+
+
+@login_required
+@require_GET
+def notification_bell_count(request: HttpRequest) -> HttpResponse:
+    return render(request, "notifications/_notification_count_indicator.html")

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -102,6 +102,10 @@ NOTIFICATION_CATEGORIES: list[dict[str, Any]] = [
 
 
 def _optional_types_for_scope(scope: str) -> list[NotificationType]:
+    """Returns the non-mandatory notification types in scope (a category
+    slug, or "master" for every category) — the ones a user can actually
+    toggle off for the app/email channels.
+    """
     mandatory = NotificationType.mandatory_types()
     if scope == "master":
         return [
@@ -117,6 +121,12 @@ def _optional_types_for_scope(scope: str) -> list[NotificationType]:
 
 
 def _all_types_for_scope(scope: str) -> list[NotificationType]:
+    """Returns every notification type in scope, including mandatory ones.
+
+    Used for the push channel: unlike app/email, push has no mandatory-type
+    carve-out, so bulk push toggles must cover the full category rather
+    than just the optional types.
+    """
     if scope == "master":
         return [ntype for cat in NOTIFICATION_CATEGORIES for ntype, _ in cat["types"]]
     for cat in NOTIFICATION_CATEGORIES:
@@ -126,6 +136,11 @@ def _all_types_for_scope(scope: str) -> list[NotificationType]:
 
 
 def _build_preferences_context(user: BorrowdUser) -> dict[str, Any]:
+    """Builds the template context for the notification preferences page:
+    per-category, per-channel toggle state for every notification type,
+    plus a flat `prefs_json` blob the page's JS reads to drive the
+    category-level "select all" switches.
+    """
     mandatory = NotificationType.mandatory_types()
     prefs: dict[str, NotificationPreference] = {
         p.notification_type: p for p in NotificationPreference.objects.filter(user=user)
@@ -198,6 +213,7 @@ def _build_preferences_context(user: BorrowdUser) -> dict[str, Any]:
 
 @login_required
 def notification_preferences_view(request: HttpRequest) -> HttpResponse:
+    """Renders the notification preferences page."""
     user = get_authenticated_user(request)
     context = _build_preferences_context(user)
     context["vapid_public_key"] = settings.VAPID_PUBLIC_KEY
@@ -207,6 +223,10 @@ def notification_preferences_view(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def toggle_preference(request: HttpRequest) -> HttpResponse:
+    """Toggles a single (notification_type, channel) preference on/off for
+    the current user. Rejects disabling a mandatory type on a non-push
+    channel — those must always stay on.
+    """
     user = get_authenticated_user(request)
     type_value = request.POST.get("notification_type", "")
     channel_value = request.POST.get("channel", "")
@@ -243,6 +263,10 @@ def toggle_preference(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def bulk_toggle_preferences(request: HttpRequest) -> HttpResponse:
+    """Toggles every applicable type in a scope (a category slug, or
+    "master" for all categories) for one channel at once — backs the
+    preferences page's category-level and global "select all" switches.
+    """
     user = get_authenticated_user(request)
     scope = request.POST.get("scope", "")
     channel_value = request.POST.get("channel", "")
@@ -300,6 +324,10 @@ def app_channel_qs(qs: QuerySet[Notification]) -> QuerySet[Notification]:
 def _notification_message_template_and_context(
     notification: Notification,
 ) -> tuple[str, dict[str, Any]]:
+    """Looks up the message template registered for a notification's verb
+    (NotificationType.message_template) and the interpolation context
+    stored on the notification by the notify.send() call that created it.
+    """
     try:
         template = NotificationType(notification.verb).message_template
     except ValueError:
@@ -316,6 +344,11 @@ def _notification_message_template_and_context(
 def _notification_message_parts(
     template: str, context: dict[str, Any], fallback_text: str
 ) -> list[NotificationMessagePart]:
+    """Splits a message template into literal and interpolated parts so the
+    notification card can render the interpolated values (e.g. an item
+    name) in bold. Falls back to `fallback_text` as a single plain part if
+    the template or context is malformed.
+    """
     formatter = Formatter()
     parts: list[NotificationMessagePart] = []
 
@@ -347,6 +380,10 @@ def _notification_message_parts(
 def _get_notification_category(
     notification_type: NotificationType,
 ) -> dict[str, Any] | None:
+    """Finds the NOTIFICATION_CATEGORIES entry a notification type belongs
+    to, returning its display title and category dict, or None if the
+    type isn't registered in any category.
+    """
     for cat in NOTIFICATION_CATEGORIES:
         for ntype, type_des in cat["types"]:
             if ntype == notification_type:
@@ -414,6 +451,7 @@ def _annotate_for_display(notifications: Iterable[Notification]) -> None:
 
 @login_required
 def notification_inbox_view(request: HttpRequest) -> HttpResponse:
+    """Renders the paginated in-app notification inbox for the current user."""
     user = get_authenticated_user(request)
 
     # only show the notifications that where sent through the in-app channel
@@ -450,6 +488,10 @@ def _redirect_to_caller(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_POST
 def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
+    """Marks a notification as read. For htmx requests, returns the
+    updated card partial so it can be swapped in place; otherwise redirects
+    back to wherever the form was submitted from.
+    """
     notification = get_object_or_404(
         Notification,
         pk=pk,
@@ -500,6 +542,10 @@ def mark_all_notifications_read(request: HttpRequest) -> HttpResponse:
 
 
 def delete_app_notification(notification: Notification) -> None:
+    """Hides a notification from the in-app inbox by flipping its metadata's
+    `visible_in_app` off, without touching its email/push delivery history.
+    Also clears `unread` so it stops counting toward the header badge.
+    """
     if NotificationMetadata.objects.filter(
         notification=notification,
         visible_in_app=True,
@@ -511,6 +557,10 @@ def delete_app_notification(notification: Notification) -> None:
 @login_required
 @require_POST
 def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
+    """Removes a single notification from the in-app inbox. For htmx
+    requests, returns an empty response so the card's outerHTML swap
+    deletes it in place; otherwise redirects back to the caller.
+    """
     notification = get_object_or_404(
         Notification,
         pk=pk,
@@ -527,6 +577,9 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def remove_all_app_notifications(request: HttpRequest) -> HttpResponse:
+    """Clears the current user's entire in-app inbox: marks every visible
+    notification read and hides it from the in-app channel.
+    """
     user = get_authenticated_user(request)
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
     visible_notifications = app_channel_qs(user.notifications.all())  # type: ignore[attr-defined]
@@ -544,6 +597,9 @@ _POPUP_NOTIFICATION_LIMIT = 5
 @login_required
 @require_GET
 def notification_popup_view(request: HttpRequest) -> HttpResponse:
+    """Renders the header bell's dropdown popup with the user's most
+    recent notifications (see _POPUP_NOTIFICATION_LIMIT).
+    """
     user = get_authenticated_user(request)
 
     # notifications is untyped (see mypy.ini): user.notifications is invisible to mypy.
@@ -569,4 +625,8 @@ def notification_popup_view(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_GET
 def notification_bell_count(request: HttpRequest) -> HttpResponse:
+    """Renders the header bell's icon/badge fragment. Polled every 30s by
+    `#notification-indicator` (notification_bell.html) to keep the unread
+    count fresh without a full page reload.
+    """
     return render(request, "notifications/_notification_count_indicator.html")

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -34,6 +34,7 @@ NOTIFICATION_CATEGORIES: list[dict[str, Any]] = [
     {
         "name": "Lending Lifecycle",
         "slug": "lending",
+        "icon": "arrows-right-left",
         "types": [
             (NotificationType.ITEM_REQUESTED, "Borrow request received"),
             (NotificationType.ITEM_REQUEST_ACCEPTED, "Request accepted"),
@@ -58,6 +59,7 @@ NOTIFICATION_CATEGORIES: list[dict[str, Any]] = [
     {
         "name": "Group & Membership",
         "slug": "membership",
+        "icon": "user-group",
         "types": [
             (
                 NotificationType.GROUP_MEMBER_JOINED,
@@ -71,6 +73,7 @@ NOTIFICATION_CATEGORIES: list[dict[str, Any]] = [
     {
         "name": "Item Availability",
         "slug": "availability",
+        "icon": "bell-alert",
         "types": [
             (NotificationType.ITEM_NOTIFY_WHEN_AVAILABLE, "Item now available"),
             (NotificationType.ITEM_SUBSCRIPTION, "Item subscription"),
@@ -79,6 +82,7 @@ NOTIFICATION_CATEGORIES: list[dict[str, Any]] = [
     {
         "name": "Ownership Transfer",
         "slug": "giveaway",
+        "icon": "gift",
         "types": [
             (NotificationType.GIVEAWAY_OFFER_SENT, "Giveaway offer received"),
             (NotificationType.GIVEAWAY_ACCEPTED, "Giveaway accepted"),
@@ -312,12 +316,19 @@ def app_channel_qs(qs: QuerySet[Notification]) -> QuerySet[Notification]:
 
     Also prefetches action_object (a GenericForeignKey, so a plain
     select_related/prefetch_related can't cover it): every notify.send()
-    call sets it to an Item or a Membership (see signals.py), and
-    _notification_action_url reads it for every row on the page, so
+    call sets it to an Item, Membership, or BorrowdGroup (see signals.py), and
+    display helpers read it for every row on the page, so
     without this each row costs its own query.
     """
     return qs.filter(borrowd_metadata__visible_in_app=True).prefetch_related(
-        GenericPrefetch("action_object", [Item.objects.all(), Membership.objects.all()])
+        GenericPrefetch(
+            "action_object",
+            [
+                Item.objects.prefetch_related("photos"),
+                Membership.objects.select_related("group", "user__profile"),
+                BorrowdGroup.objects.all(),
+            ],
+        )
     )
 
 
@@ -379,15 +390,42 @@ def _notification_message_parts(
 
 def _get_notification_category(
     notification_type: NotificationType,
-) -> dict[str, Any] | None:
+) -> tuple[str | None, str | None]:
     """Finds the NOTIFICATION_CATEGORIES entry a notification type belongs
     to, returning its display title and category dict, or None if the
     type isn't registered in any category.
     """
     for cat in NOTIFICATION_CATEGORIES:
-        for ntype, type_des in cat["types"]:
+        for ntype, title in cat["types"]:
             if ntype == notification_type:
-                return {"notification_title": type_des, "notification_category": cat}
+                try:
+                    return (str(title), str(cat["slug"]))
+                except ValueError:
+                    return (None, None)
+    return (None, None)
+
+
+def _get_category_icon(slug: str | None) -> str | None:
+    """Returns the heroicon name (see `templates/notifications/preferences.html`
+    and `{% heroicon_outline %}`) for a NOTIFICATION_CATEGORIES slug, or
+    None if no category has that slug.
+    """
+
+    if not slug:
+        return None
+
+    for cat in NOTIFICATION_CATEGORIES:
+        if cat["slug"] == slug:
+            return str(cat["icon"])
+    return None
+
+
+def _notification_action_object(
+    notification: Notification,
+) -> Item | Membership | BorrowdGroup | None:
+    action_object = notification.action_object
+    if isinstance(action_object, (Item, Membership, BorrowdGroup)):
+        return action_object
     return None
 
 
@@ -398,7 +436,7 @@ def _notification_action_url(notification: Notification) -> str | None:
     goes to its detail page, a Membership or BorrowdGroup to the group's
     detail page.
     """
-    action_object = notification.action_object
+    action_object = _notification_action_object(notification)
     if isinstance(action_object, Item):
         # A soft-deleted item's detail page 404s (ItemDetailView uses the
         # default active-only manager). item_card.html already treats
@@ -413,6 +451,49 @@ def _notification_action_url(notification: Notification) -> str | None:
         )
     if isinstance(action_object, BorrowdGroup):
         return reverse("borrowd_groups:group-detail", kwargs={"pk": action_object.pk})
+    return None
+
+
+def _image_url(image: Any) -> str | None:
+    if not image:
+        return None
+    try:
+        return str(image.url)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _item_avatar_url(item: Item) -> str | None:
+    first_photo = item.photos.first()
+    if first_photo is None:
+        return None
+    return _image_url(first_photo.thumbnail)
+
+
+def _group_avatar_url(group: BorrowdGroup) -> str | None:
+    return _image_url(group.banner or group.logo)
+
+
+def _membership_avatar_url(
+    notification: Notification, membership: Membership
+) -> str | None:
+    if notification.verb in {
+        NotificationType.GROUP_MEMBER_JOINED.value,
+        NotificationType.MEMBERSHIP_PENDING.value,
+    }:
+        return _image_url(membership.user.profile.image)
+    return _group_avatar_url(membership.group)
+
+
+def _notification_avatar_content(notification: Notification) -> str | None:
+    """Resolves the image URL shown in a notification card."""
+    action_object = _notification_action_object(notification)
+    if isinstance(action_object, Item):
+        return _item_avatar_url(action_object)
+    if isinstance(action_object, Membership):
+        return _membership_avatar_url(notification, action_object)
+    if isinstance(action_object, BorrowdGroup):
+        return _group_avatar_url(action_object)
     return None
 
 
@@ -434,19 +515,22 @@ def _annotate_for_display(notifications: Iterable[Notification]) -> None:
         except ValueError:
             notification.category = "Borrowd"
             notification.title = "Notification"
-        else:
-            cat = _get_notification_category(notification_type)
-            if cat:
-                notification.category = cat["notification_category"]
-                notification.title = cat["notification_title"]
-            else:
-                notification.category = "Borrowd"
-                notification.title = "Notification"
+
+        notification_title, category = (None, None)
+        if notification_type:
+            notification_title, category = _get_notification_category(notification_type)
+
+        notification.title = (
+            notification_title if notification_title else "Notification"
+        )
+        notification.category = category if category else "borrowd"
 
         notification.show_absolute_timestamp = (
             notification.timestamp <= relative_timestamp_cutoff
         )
         notification.action_url = _notification_action_url(notification)
+        notification.avatar_content = _notification_avatar_content(notification)
+        notification.category_icon = _get_category_icon(category)
 
 
 @login_required

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -10,6 +10,7 @@ from django.core.paginator import Paginator
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
@@ -561,6 +562,19 @@ def notification_inbox_view(request: HttpRequest) -> HttpResponse:
     )
 
 
+def _render_notification_indicator_oob(request: HttpRequest) -> str:
+    """Renders the header bell's icon/badge as an out-of-band swap fragment
+    (see `templates/notifications/_notification_indicator_oob.html`), for
+    htmx action responses to append so the badge updates immediately
+    instead of waiting for the next 30s poll. The count itself comes from
+    the `unread_notification_count` context processor, so it's always
+    freshly queried rather than manually decremented.
+    """
+    return render_to_string(
+        "notifications/_notification_indicator_oob.html", request=request
+    )
+
+
 def _redirect_to_caller(request: HttpRequest) -> HttpResponse:
     """Sends the user back to wherever they submitted the form from (the
     inbox page or the header's notification popup), rather than always
@@ -577,8 +591,9 @@ def _redirect_to_caller(request: HttpRequest) -> HttpResponse:
 @require_POST
 def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
     """Marks a notification as read. For htmx requests, returns the
-    updated card partial so it can be swapped in place; otherwise redirects
-    back to wherever the form was submitted from.
+    updated card partial plus an out-of-band header badge update, so both
+    swap in place immediately; otherwise redirects back to wherever the
+    form was submitted from.
     """
     notification = get_object_or_404(
         Notification,
@@ -589,11 +604,12 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
     notification.mark_as_read()
     if request.headers.get("HX-Request") == "true":
         _annotate_for_display([notification])
-        return render(
-            request,
+        card_html = render_to_string(
             "notifications/_notification_card.html",
             {"notification": notification},
+            request=request,
         )
+        return HttpResponse(card_html + _render_notification_indicator_oob(request))
     return _redirect_to_caller(request)
 
 
@@ -646,8 +662,9 @@ def delete_app_notification(notification: Notification) -> None:
 @require_POST
 def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
     """Removes a single notification from the in-app inbox. For htmx
-    requests, returns an empty response so the card's outerHTML swap
-    deletes it in place; otherwise redirects back to the caller.
+    requests, returns an out-of-band header badge update with no other
+    content, so the card's outerHTML swap deletes it in place and the
+    badge updates immediately; otherwise redirects back to the caller.
     """
     notification = get_object_or_404(
         Notification,
@@ -658,7 +675,10 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
 
     delete_app_notification(notification=notification)
     if request.headers.get("HX-Request") == "true":
-        return HttpResponse("")
+        # No main content: the card's outerHTML target swaps to nothing
+        # (removing it), while the OOB fragment updates the badge in the
+        # same response.
+        return HttpResponse(_render_notification_indicator_oob(request))
     return _redirect_to_caller(request)
 
 

--- a/borrowd_notifications/views.py
+++ b/borrowd_notifications/views.py
@@ -457,6 +457,13 @@ def mark_notification_read(request: HttpRequest, pk: int) -> HttpResponse:
         borrowd_metadata__visible_in_app=True,
     )
     notification.mark_as_read()
+    if request.headers.get("HX-Request") == "true":
+        _annotate_for_display([notification])
+        return render(
+            request,
+            "notifications/_notification_card.html",
+            {"notification": notification},
+        )
     return _redirect_to_caller(request)
 
 
@@ -512,6 +519,8 @@ def remove_app_notification(request: HttpRequest, pk: int) -> HttpResponse:
     )
 
     delete_app_notification(notification=notification)
+    if request.headers.get("HX-Request") == "true":
+        return HttpResponse("")
     return _redirect_to_caller(request)
 
 

--- a/e2e_tests/pages/notification_bell_page.py
+++ b/e2e_tests/pages/notification_bell_page.py
@@ -1,0 +1,31 @@
+import re
+
+from playwright.sync_api import Page, expect
+
+
+class NotificationBellPage:
+    """The notification bell and its click-to-open dropdown, present in the
+    header on every authenticated page."""
+
+    def __init__(self, page: Page):
+        self.page = page
+        self.bell_trigger = page.get_by_role("button", name="Notifications")
+        self.badge = page.locator("#nav-unread-count")
+        self.popup_list = page.locator("#notification-popup-list")
+        self.popup_cards = page.get_by_test_id("notification-card")
+        self.popup_empty_state = page.get_by_text("No notifications yet.")
+        self.view_all_link = page.get_by_role("link", name="View all")
+        self.inbox_heading = page.get_by_role("heading", name="Notifications")
+
+    def open(self):
+        self.bell_trigger.click()
+        expect(self.popup_list).to_be_visible()
+
+    def expect_popup_has_content_or_empty_state(self):
+        expect(self.popup_cards.first.or_(self.popup_empty_state)).to_be_visible()
+
+    def click_view_all(self):
+        expect(self.view_all_link).to_be_visible()
+        self.view_all_link.click()
+        expect(self.page).to_have_url(re.compile(r"/notifications/?$"))
+        expect(self.inbox_heading).to_be_visible()

--- a/e2e_tests/tests/test_notification_bell.py
+++ b/e2e_tests/tests/test_notification_bell.py
@@ -1,0 +1,62 @@
+import allure
+import pytest
+from pages.notification_bell_page import NotificationBellPage
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@allure.feature("Notifications")
+@allure.title("Notification bell opens a popup with recent notifications")
+@allure.severity(allure.severity_level.NORMAL)
+def test_bell_opens_popup(user_page, base_url):
+    with allure.step("Navigate to an authenticated page"):
+        user_page.goto(f"{base_url}/items/", wait_until="domcontentloaded")
+
+    with allure.step("Open the notification popup"):
+        bell = NotificationBellPage(user_page)
+        bell.open()
+
+    with allure.step("Popup shows notifications or the empty state"):
+        bell.expect_popup_has_content_or_empty_state()
+
+
+@pytest.mark.regression
+@allure.feature("Notifications")
+@allure.title("'View all' in the popup navigates to the notification inbox")
+@allure.severity(allure.severity_level.NORMAL)
+def test_popup_view_all_navigates_to_inbox(user_page, base_url):
+    with allure.step("Open the notification popup"):
+        user_page.goto(f"{base_url}/items/", wait_until="domcontentloaded")
+        bell = NotificationBellPage(user_page)
+        bell.open()
+
+    with allure.step("Click 'View all' and land on the inbox page"):
+        bell.click_view_all()
+
+
+@pytest.mark.regression
+@allure.feature("Notifications")
+@allure.title("Unread badge does not duplicate on the 30s htmx poll")
+@allure.severity(allure.severity_level.NORMAL)
+def test_unread_badge_does_not_duplicate_on_poll(user_page, base_url):
+    """Regression test for a bug where the badge's htmx poll selected two
+    elements with the same id from the full inbox-page response (the
+    navbar's own badge and the inbox page's inline badge) and swapped both
+    in, doubling the badge. Both now use distinct ids so only one is ever
+    matched.
+    """
+    with allure.step("Navigate to an authenticated page"):
+        user_page.goto(f"{base_url}/items/", wait_until="domcontentloaded")
+
+    bell = NotificationBellPage(user_page)
+    if bell.badge.count() == 0:
+        pytest.skip("Test account has no unread notifications to show a badge for")
+
+    with allure.step("Badge renders once before the poll fires"):
+        assert bell.badge.count() == 1
+
+    with allure.step("Wait past the 30s htmx poll interval"):
+        user_page.wait_for_timeout(32_000)
+
+    with allure.step("Badge still renders exactly once after polling"):
+        assert bell.badge.count() == 1

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -100,6 +100,18 @@ TODO: Transfer over all to daisy */
   .btn-waitlisted:hover {
     --btn-bg: rgb(156 163 175 / 0.25);
   }
+
+  .notification-card.notification-card-reading {
+    background-color: var(--color-primary-content);
+  }
+
+  .notification-card.notification-card-removing.htmx-swapping {
+    opacity: 0;
+    transform: translateX(0.75rem);
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 /* Toast alert variants */
 @layer utilities {

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -25,12 +25,12 @@
         </div>
         <div class="navbar-end">
             {% if user.is_authenticated %}
-                <!-- currently empty. Avatar picture in future? -->
-                <div class="w-12">
-                </div>
+                {% include "notifications/notification_bell.html" %}
+
             {% endif %}
         </div>
     </div>
+
     <!-- Drawer/Sidebar -->
     {% if user.is_authenticated %}
         <div class="drawer">

--- a/templates/notifications/_notification_card.html
+++ b/templates/notifications/_notification_card.html
@@ -1,7 +1,8 @@
 {% load i18n heroicons static humanize %}
 
-<div data-testid="notification-card"
-     class="px-4 py-4 hover:bg-blue-50/70 {% if notification.unread %}bg-blue-50/70{% else %}bg-primary-content{% endif %}">
+<div id="notification-card-{{ notification.pk }}"
+     data-testid="notification-card"
+     class="notification-card max-h-80 overflow-hidden px-4 py-4 transition-all duration-200 ease-out hover:bg-blue-50/70 motion-reduce:transition-none {% if notification.unread %}bg-blue-50/70{% else %}bg-primary-content{% endif %}">
     <div class="flex min-w-0 items-start gap-3">
         {% if notification.action_url %}
             <form method="post"
@@ -18,8 +19,8 @@
                          alt=""
                          class="size-10 shrink-0 rounded-full object-cover bg-base-200" />
 
-                    <div class="min-w-0 flex flex-col flex-1 gap-3">
-                        <div class="flex flex-col items-start justify-between gap-2">
+                    <span class="min-w-0 flex flex-col flex-1 gap-3">
+                        <span class="flex flex-col items-start justify-between gap-2">
                             <span class="min-w-0 text-sm leading-snug text-base-content line-clamp-2 font-semibold">
                                 {{ notification.title }}
                             </span>
@@ -30,7 +31,7 @@
                                     {{ notification.timestamp|naturaltime }}
                                 {% endif %}
                             </span>
-                        </div>
+                        </span>
 
                         <span class="block text-sm leading-snug text-base-content/60 line-clamp-3">
                             {% for part in notification.message_parts %}
@@ -41,7 +42,7 @@
                                 {% endif %}
                             {% endfor %}
                         </span>
-                    </div>
+                    </span>
 
                     {% if notification.action_url %}
                     </button>
@@ -53,7 +54,11 @@
         <div class="flex shrink-0 items-start gap-1">
             {% if notification.unread %}
                 <form method="post"
-                      action="{% url 'notification-mark-read' pk=notification.pk %}">
+                      action="{% url 'notification-mark-read' pk=notification.pk %}"
+                      hx-post="{% url 'notification-mark-read' pk=notification.pk %}"
+                      hx-target="#notification-card-{{ notification.pk }}"
+                      hx-swap="outerHTML swap:200ms"
+                      hx-on::before-request="this.closest('.notification-card').classList.add('notification-card-reading')">
                     {% csrf_token %}
                     {% trans "Mark as read" as mark_read_label %}
                     <button type="submit"
@@ -67,7 +72,11 @@
             {% endif %}
 
             <form method="post"
-                  action="{% url 'notification-delete' pk=notification.pk %}">
+                  action="{% url 'notification-delete' pk=notification.pk %}"
+                  hx-post="{% url 'notification-delete' pk=notification.pk %}"
+                  hx-target="#notification-card-{{ notification.pk }}"
+                  hx-swap="outerHTML swap:200ms"
+                  hx-on::before-request="this.closest('.notification-card').classList.add('notification-card-removing')">
                 {% csrf_token %}
                 {% trans "Delete" as delete_label %}
                 <button type="submit"

--- a/templates/notifications/_notification_card.html
+++ b/templates/notifications/_notification_card.html
@@ -15,9 +15,20 @@
                     <div class="flex min-w-0 flex-1 items-start gap-3">
                     {% endif %}
 
-                    <img src="{% static 'icon.svg' %}"
-                         alt=""
-                         class="size-10 shrink-0 rounded-full object-cover bg-base-200" />
+                    <div class="indicator shrink-0">
+                        {% if notification.avatar_content %}
+                            <img src="{{ notification.avatar_content }}"
+                                 alt=""
+                                 class="size-12 rounded-full object-cover bg-base-200 border-2 border-white" />
+                        {% else %}
+                            <span class="size-12 rounded-full bg-base-200 border-2 border-white flex items-center justify-center">
+                                {% heroicon_solid notification.category_icon|default:"bell" class="size-5" %}
+                            </span>
+                        {% endif %}
+                        {% if notification.unread %}
+                            <span class="indicator-item bg-accent w-3 h-3 mt-2 mr-1 rounded-full border-2 border-white" />
+                        {% endif %}
+                    </div>
 
                     <span class="min-w-0 flex flex-col flex-1 gap-3">
                         <span class="flex flex-col items-start justify-between gap-2">

--- a/templates/notifications/_notification_card.html
+++ b/templates/notifications/_notification_card.html
@@ -26,7 +26,7 @@
                             </span>
                         {% endif %}
                         {% if notification.unread %}
-                            <span class="indicator-item bg-accent w-3 h-3 mt-2 mr-1 rounded-full border-2 border-white" />
+                            <span class="indicator-item bg-accent w-3 h-3 mt-2 mr-1 rounded-full border-2 border-white"></span>
                         {% endif %}
                     </div>
 

--- a/templates/notifications/_notification_card.html
+++ b/templates/notifications/_notification_card.html
@@ -1,0 +1,82 @@
+{% load i18n heroicons static humanize %}
+
+<div data-testid="notification-card"
+     class="px-4 py-4 hover:bg-blue-50/70 {% if notification.unread %}bg-blue-50/70{% else %}bg-primary-content{% endif %}">
+    <div class="flex min-w-0 items-start gap-3">
+        {% if notification.action_url %}
+            <form method="post"
+                  action="{% url 'notification-open' pk=notification.pk %}"
+                  class="min-w-0 flex-1">
+                {% csrf_token %}
+                <button type="submit"
+                        class="flex w-full min-w-0 items-start gap-3 rounded-md text-left cursor-pointer">
+                {% else %}
+                    <div class="flex min-w-0 flex-1 items-start gap-3">
+                    {% endif %}
+
+                    <img src="{% static 'icon.svg' %}"
+                         alt=""
+                         class="size-10 shrink-0 rounded-full object-cover bg-base-200" />
+
+                    <div class="min-w-0 flex flex-col flex-1 gap-3">
+                        <div class="flex flex-col items-start justify-between gap-2">
+                            <span class="min-w-0 text-sm leading-snug text-base-content line-clamp-2 font-semibold">
+                                {{ notification.title }}
+                            </span>
+                            <span class="shrink-0 whitespace-nowrap text-xs leading-none text-base-content/50">
+                                {% if notification.show_absolute_timestamp %}
+                                    {{ notification.timestamp|date:"M j, Y" }}
+                                {% else %}
+                                    {{ notification.timestamp|naturaltime }}
+                                {% endif %}
+                            </span>
+                        </div>
+
+                        <span class="block text-sm leading-snug text-base-content/60 line-clamp-3">
+                            {% for part in notification.message_parts %}
+                                {% if part.is_emphasized %}
+                                    <span class="font-semibold">{{ part.text }}</span>
+                                {% else %}
+                                    {{ part.text }}
+                                {% endif %}
+                            {% endfor %}
+                        </span>
+                    </div>
+
+                    {% if notification.action_url %}
+                    </button>
+                </form>
+            {% else %}
+            </div>
+        {% endif %}
+
+        <div class="flex shrink-0 items-start gap-1">
+            {% if notification.unread %}
+                <form method="post"
+                      action="{% url 'notification-mark-read' pk=notification.pk %}">
+                    {% csrf_token %}
+                    {% trans "Mark as read" as mark_read_label %}
+                    <button type="submit"
+                            class="btn btn-ghost btn-xs inline-flex items-center gap-1 whitespace-nowrap px-2 text-borrowd-indigo-600"
+                            aria-label="{{ mark_read_label }}"
+                            title="{{ mark_read_label }}">
+                        {% heroicon_outline "envelope-open" class="size-5" %}
+                        <span class="hidden sm:inline">{{ mark_read_label }}</span>
+                    </button>
+                </form>
+            {% endif %}
+
+            <form method="post"
+                  action="{% url 'notification-delete' pk=notification.pk %}">
+                {% csrf_token %}
+                {% trans "Delete" as delete_label %}
+                <button type="submit"
+                        class="btn btn-ghost btn-xs inline-flex size-7 items-center justify-center p-0 text-red-600"
+                        aria-label="{{ delete_label }}"
+                        title="{{ delete_label }}">
+                    {% heroicon_solid "trash" class="size-5" %}
+                </button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/templates/notifications/_notification_count_indicator.html
+++ b/templates/notifications/_notification_count_indicator.html
@@ -2,7 +2,8 @@
 
 {% if unread_notification_count %}
     {% heroicon_solid "bell" class="h-5 w-5" %}
-    <span id="nav-unread-count" class="indicator-item badge badge-primary badge-xs">
+    <span id="nav-unread-count"
+          class="indicator-item badge badge-primary badge-xs">
         {{ unread_notification_count }}
     </span>
 {% else %}

--- a/templates/notifications/_notification_count_indicator.html
+++ b/templates/notifications/_notification_count_indicator.html
@@ -2,7 +2,7 @@
 
 {% if unread_notification_count %}
     {% heroicon_solid "bell" class="h-5 w-5" %}
-    <span class="indicator-item badge badge-primary badge-xs">
+    <span id="nav-unread-count" class="indicator-item badge badge-primary badge-xs">
         {{ unread_notification_count }}
     </span>
 {% else %}

--- a/templates/notifications/_notification_count_indicator.html
+++ b/templates/notifications/_notification_count_indicator.html
@@ -1,0 +1,10 @@
+{% load heroicons %}
+
+{% if unread_notification_count %}
+    {% heroicon_solid "bell" class="h-5 w-5" %}
+    <span class="indicator-item badge badge-primary badge-xs">
+        {{ unread_notification_count }}
+    </span>
+{% else %}
+    {% heroicon_outline "bell" class="h-5 w-5" %}
+{% endif %}

--- a/templates/notifications/_notification_indicator_oob.html
+++ b/templates/notifications/_notification_indicator_oob.html
@@ -1,0 +1,10 @@
+<div id="notification-indicator"
+     hx-swap-oob="true"
+     class="indicator"
+     hx-get="{% url 'notification-bell-count' %}"
+     hx-trigger="load, every 30s"
+     hx-target="this"
+     hx-swap="innerHTML">
+    {% include "notifications/_notification_count_indicator.html" %}
+
+</div>

--- a/templates/notifications/inbox.html
+++ b/templates/notifications/inbox.html
@@ -34,7 +34,8 @@
             {% if page_obj.object_list %}
                 <form method="post" action="{% url 'notification-delete-all' %}">
                     {% csrf_token %}
-                    <button type="submit" class="btn btn-warning btn-sm text-base-content/60">
+                    <button type="submit" class="btn btn-sm text-red-600 gap-1.5">
+                        {% heroicon_mini "trash" class="size-4" %}
                         {% trans "Delete all" %}
                     </button>
                 </form>
@@ -46,42 +47,8 @@
                  {% if not page_obj.number or page_obj.number == 1 %} hx-get="{% url 'notification-inbox' %}" hx-trigger="every 30s" hx-select="#notification-list" hx-swap="outerHTML" {% endif %}
                  class="card bg-primary-content rounded-md border border-gray-200 shadow-sm divide-y divide-gray-100">
                 {% for notification in page_obj %}
-                    <div class="flex items-start gap-3 px-4 py-3 {% if notification.unread %}bg-blue-50/60{% endif %}">
+                    {% include "notifications/_notification_card.html" %}
 
-                        <span class="mt-2 h-2 w-2 rounded-full flex-shrink-0 {% if notification.unread %}bg-primary{% endif %}"></span>
-
-                        <div class="flex-1 min-w-0">
-                            <p class="text-sm {% if notification.unread %}font-medium{% endif %}">
-                                {{ notification.formatted_message }}
-                            </p>
-                            <p class="text-xs text-base-content/50 mt-0.5">
-                                {% if notification.show_absolute_timestamp %}
-                                    {{ notification.timestamp|date:"M j, Y" }}
-                                {% else %}
-                                    {{ notification.timestamp|naturaltime }}
-                                {% endif %}
-                            </p>
-                        </div>
-
-                        {% if notification.unread %}
-                            <form method="post"
-                                  action="{% url 'notification-mark-read' pk=notification.pk %}">
-                                {% csrf_token %}
-                                <button type="submit"
-                                        class="btn btn-ghost btn-xs text-base-content/40 mt-0.5">
-                                    {% trans "Mark as read" %}
-                                </button>
-                            </form>
-                        {% endif %}
-                        <form method="post"
-                              action="{% url 'notification-delete' pk=notification.pk %}">
-                            {% csrf_token %}
-                            <button type="submit"
-                                    class="btn btn-warning btn-xs text-base-content/40 mt-0.5">
-                                {% heroicon_outline "trash" class="size-5" %}
-                            </button>
-                        </form>
-                    </div>
                 {% endfor %}
             </div>
 

--- a/templates/notifications/inbox.html
+++ b/templates/notifications/inbox.html
@@ -16,13 +16,13 @@
                 <h1 class="text-xl font-semibold">
                     {% trans "Notifications" %}
                 </h1>
-                {% if unread_count %}
+                {% if unread_notification_count %}
                     <span id="unread-count"
                           class="badge badge-primary badge-sm"
-                          {% if not page_obj.number or page_obj.number == 1 %} hx-get="{% url 'notification-inbox' %}" hx-trigger="every 30s" hx-select="#unread-count" hx-swap="outerHTML" {% endif %}>{{ unread_count }}</span>
+                          {% if not page_obj.number or page_obj.number == 1 %} hx-get="{% url 'notification-inbox' %}" hx-trigger="every 30s" hx-select="#unread-count" hx-swap="outerHTML" {% endif %}>{{ unread_notification_count }}</span>
                 {% endif %}
             </div>
-            {% if unread_count %}
+            {% if unread_notification_count %}
                 <form method="post" action="{% url 'notification-mark-all-read' %}">
                     {% csrf_token %}
                     <button type="submit" class="btn btn-ghost btn-sm text-base-content/60">

--- a/templates/notifications/notification_bell.html
+++ b/templates/notifications/notification_bell.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load heroicons %}
 
 <div class="dropdown dropdown-end">
     <!-- daisyUI sets pointer-events:none on this element the instant it gains
@@ -14,15 +13,14 @@
          hx-trigger="focus once"
          hx-target="#notification-popup-content"
          hx-swap="innerHTML">
-        <div class="indicator">
-            {% if unread_count %}
-                {% heroicon_solid "bell" class="h-5 w-5" %}
-                <span id="nav-unread-count"
-                      class="indicator-item badge badge-primary badge-xs"
-                      hx-get="{% url 'notification-popup' %}">{{ unread_count }}</span>
-            {% else %}
-                {% heroicon_outline "bell" class="h-5 w-5" %}
-            {% endif %}
+        <div id="notification-indicator"
+             class="indicator"
+             hx-get="{% url 'notification-bell-count' %}"
+             hx-trigger="load, every 30s"
+             hx-target="this"
+             hx-swap="innerHTML">
+            {% include "notifications/_notification_count_indicator.html" %}
+
         </div>
     </div>
     <div id="notification-popup-content"

--- a/templates/notifications/notification_bell.html
+++ b/templates/notifications/notification_bell.html
@@ -10,7 +10,7 @@
          class="btn btn-ghost text-borrowd-indigo-600 btn-circle md:mr-6"
          aria-label="{% trans 'Notifications' %}"
          hx-get="{% url 'notification-popup' %}"
-         hx-trigger="focus once"
+         hx-trigger="focus"
          hx-target="#notification-popup-content"
          hx-swap="innerHTML">
         <div id="notification-indicator"

--- a/templates/notifications/notification_bell.html
+++ b/templates/notifications/notification_bell.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load heroicons %}
+
+<div class="dropdown dropdown-end">
+    <!-- daisyUI sets pointer-events:none on this element the instant it gains
+         focus (to let clicks pass through to the dropdown-content beneath),
+         so a click-triggered load races that CSS change and never fires;
+         focus doesn't race it and fires on click too. -->
+    <div tabindex="0"
+         role="button"
+         class="btn btn-ghost text-borrowd-indigo-600 btn-circle md:mr-6"
+         aria-label="{% trans 'Notifications' %}"
+         hx-get="{% url 'notification-popup' %}"
+         hx-trigger="focus once"
+         hx-target="#notification-popup-content"
+         hx-swap="innerHTML">
+        <div class="indicator">
+            {% if unread_count %}
+                {% heroicon_solid "bell" class="h-5 w-5" %}
+                <span id="nav-unread-count"
+                      class="indicator-item badge badge-primary badge-xs"
+                      hx-get="{% url 'notification-popup' %}">{{ unread_count }}</span>
+            {% else %}
+                {% heroicon_outline "bell" class="h-5 w-5" %}
+            {% endif %}
+        </div>
+    </div>
+    <div id="notification-popup-content"
+         tabindex="0"
+         class="dropdown-content z-60 mt-5 w-90 md:w-200">
+    </div>
+</div>

--- a/templates/notifications/popup.html
+++ b/templates/notifications/popup.html
@@ -1,0 +1,39 @@
+{% load i18n heroicons %}
+
+<div id="notification-popup-list"
+     class="card bg-primary-content rounded-md border border-gray-200 shadow-sm max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain">
+    <div class="sticky top-0 z-10 flex items-center justify-between gap-3 bg-primary-content px-5 py-4 border-b border-gray-100">
+        <h2 class="text-md font-semibold text-base-content">
+            {% trans "Notifications" %}
+        </h2>
+        {% if unread_count %}
+            <form method="post" action="{% url 'notification-mark-all-read' %}">
+                {% csrf_token %}
+                <button type="submit"
+                        class="btn btn-ghost btn-xs px-2 text-xs font-semibold text-borrowd-indigo-600 hover:bg-transparent">
+                    {% heroicon_outline "envelope-open" class="size-5" %}
+                    {% trans "Mark all as read" %}
+                </button>
+            </form>
+        {% endif %}
+    </div>
+
+    <div class="divide-y divide-gray-100">
+        {% if notifications %}
+            {% for notification in notifications %}
+                {% include "notifications/_notification_card.html" %}
+
+            {% endfor %}
+        {% else %}
+            <div class="flex flex-col items-center justify-center py-16 gap-2 text-base-content/40">
+                <p class="text-sm">
+                    {% trans "No notifications yet." %}
+                </p>
+            </div>
+        {% endif %}
+    </div>
+
+    <div class="px-5 py-4">
+        <a class="btn btn-primary w-full" href="{% url 'notification-inbox' %}">{% trans "View all" %}</a>
+    </div>
+</div>

--- a/templates/notifications/popup.html
+++ b/templates/notifications/popup.html
@@ -6,7 +6,7 @@
         <h2 class="text-md font-semibold text-base-content">
             {% trans "Notifications" %}
         </h2>
-        {% if unread_count %}
+        {% if unread_notification_count %}
             <form method="post" action="{% url 'notification-mark-all-read' %}">
                 {% csrf_token %}
                 <button type="submit"


### PR DESCRIPTION
## Summary
Adds the front-end notification experience: a notification bell to the authenticated header with unread count polling, a recent-notifications popup, clickable notification cards, inline htmx read/delete actions, safer redirects, and richer notification card content with category icons or related item/group/user image. 
Closing out Feature 2 of the notification system epic.

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #494  and  #492

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
- templates/notifications/notification_bell.html, templates/includes/header.html — bell icon + unread badge in the nav bar, polled every 30s via htmx
- templates/notifications/popup.html, _notification_card.html, _notification_count_indicator.html — dropdown popup with recent notifications, category icon/avatar fallback, unread indicator dot, delete animation
- templates/notifications/inbox.html — paginated (25/page) notification history page with live refresh
- borrowd_notifications/views.py — new views for the popup, bell count, open/mark-read/mark-all-read/remove/remove-all actions, plus helpers for message formatting, category/icon lookup, and avatar resolution
- borrowd_notifications/context_processors.py — unread_notification_count context processor feeding the header badge
- borrowd/util.py — is_safe_back_url helper so mark-read/delete actions redirect back to the referring page safely
- borrowd_notifications/models.py, signals.py — notification message wording tweaks
- e2e_tests/ — new bell/popup Playwright coverage

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Log in and trigger a notification (e.g. request to borrow an item from another account).
2. Confirm the header bell badge appears within 30s without a page reload.
3. Click the bell — verify the dropdown shows recent notifications, "Mark all as read", and "View all".
4. Click a notification card — verify it marks read and navigates to the linked item/group.
5. Go to /notifications/ — verify pagination, mark-all-read, and per-card delete (with animation).
6. Trigger a notification whose target item/group is soft-deleted — verify the text is preserved but the link is disabled instead of 404ing.

## Screenshots (if UI change)
<!-- Before / After if applicable -->
<img width="410" height="778" alt="Screenshot 2026-07-26 at 8 58 11 PM" src="https://github.com/user-attachments/assets/55b4c241-45ba-42ec-9fc0-c10eb0f2095c" />
<img width="402" height="737" alt="Screenshot 2026-07-26 at 8 58 44 PM" src="https://github.com/user-attachments/assets/7232c169-de07-4384-8c91-1ad0004718b9" />
<img width="1038" height="872" alt="Screenshot 2026-07-26 at 8 59 02 PM" src="https://github.com/user-attachments/assets/b7f4d04f-6a71-4363-b5e2-f1971f2c9340" />

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [x] No debug logs, or unrelated changes included
- [x] Migrations are included (if model changes were made) — none needed, no schema changes

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
- AC 5.3/5.4 in #494 call for WebSocket/SSE real-time updates with a polling fallback; this PR ships 30s htmx polling only, no live push. Flagging as a scope call, not an oversight.
- "Action-Required" vs "Informational" visual distinction (AC 6.6) isn't implemented yet.