### PR TITLE
Lender now can confirm item returned without waiting for Borrower confirmation

### DIFF
--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -534,8 +534,11 @@ class Item(Model):
                 # Otherwise, nothing to do but wait...
                 return tuple()
         elif current_tx.status == TransactionStatus.COLLECTED:
-            # Either borrower or lender can assert return.
-            # The lender can also request the item back, or give it away.
+            # Either borrower or lender can mark the item returned. The lender
+            # has it back in hand, so their mark closes the loan immediately;
+            # the borrower's is only an assertion pending the lender's
+            # confirmation. The lender can also request the item back, or
+            # give it away.
             if self.owner == user:
                 return (
                     ItemAction.MARK_RETURNED,
@@ -558,7 +561,9 @@ class Item(Model):
             # The borrower confirms the return or flags that they can't return the item.
             return (ItemAction.MARK_RETURNED, ItemAction.FLAG_CANNOT_RETURN)
         elif current_tx.status == TransactionStatus.RETURN_ASSERTED:
-            # Make sure the same person doesn't confirm the assertion
+            # Reached only via the borrower's assertion -- the lender's
+            # mark closes the loan directly without passing through this
+            # status. Make sure the same person doesn't confirm the assertion.
             if current_tx.updated_by != user:
                 if self.owner == user:
                     # The lender can deny the borrower's return claim.
@@ -817,10 +822,21 @@ class Item(Model):
                     self.status = ItemStatus.BORROWED
                     self.save()
                 case ItemAction.MARK_RETURNED:
-                    # Either party can assert return.
-                    current_tx.status = TransactionStatus.RETURN_ASSERTED
-                    current_tx.updated_by = user
-                    current_tx.save()
+                    if self.owner == user:
+                        # The lender has the item back in hand, which is
+                        # authoritative on its own -- close the loan out
+                        # immediately rather than waiting on the borrower
+                        # to confirm, so the lender can relist right away.
+                        self.status = ItemStatus.AVAILABLE
+                        self.save()
+                        current_tx.status = TransactionStatus.RETURNED
+                        current_tx.updated_by = user
+                        current_tx.save()
+                    else:
+                        # The borrower's assertion still needs the lender's confirmation.
+                        current_tx.status = TransactionStatus.RETURN_ASSERTED
+                        current_tx.updated_by = user
+                        current_tx.save()
                 case ItemAction.CONFIRM_RETURNED | ItemAction.RESOLVE_DISPUTE_RETURNED:
                     # The other party confirms return or lender resolved dispute happily
                     self.status = ItemStatus.AVAILABLE

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -822,20 +822,6 @@ class Item(Model):
                     self.status = ItemStatus.BORROWED
                     self.save()
                 case ItemAction.MARK_RETURNED:
-                    if self.owner == user:
-                        # The lender has the item back in hand, which is
-                        # authoritative on its own -- close the loan out
-                        # immediately rather than waiting on the borrower
-                        # to confirm, so the lender can relist right away.
-                        self.status = ItemStatus.AVAILABLE
-                        self.save()
-                        current_tx.status = TransactionStatus.RETURNED
-                        current_tx.updated_by = user
-                        current_tx.save()
-                    else:
-                        # The borrower's assertion still needs the lender's confirmation.
-                        current_tx.status = TransactionStatus.RETURN_ASSERTED
-                        current_tx.updated_by = user
                     # The borrower's assertion still needs the lender's confirmation.
                     current_tx.status = TransactionStatus.RETURN_ASSERTED
                     current_tx.updated_by = user

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -541,7 +541,7 @@ class Item(Model):
             # give it away.
             if self.owner == user:
                 return (
-                    ItemAction.MARK_RETURNED,
+                    ItemAction.CONFIRM_RETURNED,
                     ItemAction.REQUEST_RETURN,
                     ItemAction.OFFER_GIVEAWAY,
                 )

--- a/borrowd_items/models.py
+++ b/borrowd_items/models.py
@@ -836,7 +836,10 @@ class Item(Model):
                         # The borrower's assertion still needs the lender's confirmation.
                         current_tx.status = TransactionStatus.RETURN_ASSERTED
                         current_tx.updated_by = user
-                        current_tx.save()
+                    # The borrower's assertion still needs the lender's confirmation.
+                    current_tx.status = TransactionStatus.RETURN_ASSERTED
+                    current_tx.updated_by = user
+                    current_tx.save()
                 case ItemAction.CONFIRM_RETURNED | ItemAction.RESOLVE_DISPUTE_RETURNED:
                     # The other party confirms return or lender resolved dispute happily
                     self.status = ItemStatus.AVAILABLE

--- a/e2e_tests/tests/test_borrow_return_flow.py
+++ b/e2e_tests/tests/test_borrow_return_flow.py
@@ -50,13 +50,9 @@ def test_borrow_and_return_item(borrower_page: Page, lender_page: Page):
         lender_search_page.confirm_returned_modal_opens()
         lender_search_page.confirm_returned_modal_click_confirm_returned()
 
-    with allure.step("Borrower confirms return"):
-        borrower_search_page.page.reload()
-        borrower_search_page.click_confirm_returned_button()
-        borrower_search_page.confirm_returned_modal_borrower_opens()
-        borrower_search_page.confirm_returned_modal_borrower_click_confirm_returned()
-
-    with allure.step("Item is available again"):
+    with allure.step(
+        "Item is available again immediately, without borrower confirmation"
+    ):
         borrower_search_page.page.reload()
         borrower_search_page.expect_opened()
         borrower_search_page.expect_item_is_available()

--- a/templates/components/items/modals/_mark_returned_modal_content.html
+++ b/templates/components/items/modals/_mark_returned_modal_content.html
@@ -2,5 +2,9 @@
     Please confirm that this item has been returned.
 </p>
 <p class="mt-2 text-sm">
-    Both the lender and borrower must confirm before the loan is marked complete.
+    {% if request.user == item.owner %}
+        As the lender, your confirmation closes out the loan right away.
+    {% else %}
+        The lender will still need to confirm before the loan is marked complete.
+    {% endif %}
 </p>

--- a/tests/test_giveaway_flows.py
+++ b/tests/test_giveaway_flows.py
@@ -124,7 +124,7 @@ class GiveawayHappyFlowTest(GiveawayFlowTestBase):
         self.assertEqual(
             self.item.get_actions_for(self.lender),
             (
-                ItemAction.MARK_RETURNED,
+                ItemAction.CONFIRM_RETURNED,
                 ItemAction.REQUEST_RETURN,
                 ItemAction.OFFER_GIVEAWAY,
             ),

--- a/tests/test_return_flows.py
+++ b/tests/test_return_flows.py
@@ -350,7 +350,7 @@ class LenderMarkReturnedClosesImmediatelyTest(ReturnFlowTestBase):
 
     def test_010_lender_marks_returned_closes_loan(self) -> None:
         """The lender's mark closes the transaction and frees the item."""
-        self.post_action(self.lender, ItemAction.MARK_RETURNED)
+        self.post_action(self.lender, ItemAction.CONFIRM_RETURNED)
         tx = self.current_tx()
         self.assertEqual(tx.status, TransactionStatus.RETURNED)
         self.item.refresh_from_db()

--- a/tests/test_return_flows.py
+++ b/tests/test_return_flows.py
@@ -119,7 +119,7 @@ class ReturnRequestedHappyFlowTest(ReturnFlowTestBase):
         self.assertTupleEqual(
             self.item.get_actions_for(self.lender),
             (
-                ItemAction.MARK_RETURNED,
+                ItemAction.CONFIRM_RETURNED,
                 ItemAction.REQUEST_RETURN,
                 ItemAction.OFFER_GIVEAWAY,
             ),

--- a/tests/test_return_flows.py
+++ b/tests/test_return_flows.py
@@ -334,26 +334,34 @@ class LenderDeniesReturnAssertionFlowTest(ReturnFlowTestBase):
         self.assertEqual(tx.dispute_raised_by, self.lender)
 
 
-class BorrowerCannotDisputeLenderAssertionTest(ReturnFlowTestBase):
+class LenderMarkReturnedClosesImmediatelyTest(ReturnFlowTestBase):
     """
-    When the lender asserts the return themselves, the borrower may only
-    confirm -- the dispute deny-path is lender-only.
+    COLLECTED -> lender marks the item returned -> the loan closes right
+    away. The item is back in the lender's hands, which is authoritative
+    on its own, so the lender doesn't have to wait on the borrower to
+    confirm before the item is available to lend out again.
     """
 
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        cls.create_loan_fixtures("ret_noborrower")
+        cls.create_loan_fixtures("ret_lenderclose")
         cls.advance_to_collected()
 
-    def test_010_borrower_gets_confirm_only(self) -> None:
-        """Borrower sees only the confirm action on the lender's assertion."""
+    def test_010_lender_marks_returned_closes_loan(self) -> None:
+        """The lender's mark closes the transaction and frees the item."""
         self.post_action(self.lender, ItemAction.MARK_RETURNED)
+        tx = self.current_tx()
+        self.assertEqual(tx.status, TransactionStatus.RETURNED)
+        self.item.refresh_from_db()
+        self.assertEqual(self.item.status, ItemStatus.AVAILABLE)
+
+    def test_020_borrower_has_no_pending_actions(self) -> None:
+        """With the loan already closed, the borrower has nothing to confirm."""
         self.assertTupleEqual(
             self.item.get_actions_for(self.borrower),
-            (ItemAction.CONFIRM_RETURNED,),
+            (ItemAction.REQUEST_ITEM,),
         )
-        # Lender asserted directly (no return request): borrower-facing chip copy must not show.
         self.assertIsNone(self.item.get_action_context_for(self.lender).waiting_text)
         self.assertIsNone(self.item.get_action_context_for(self.borrower).waiting_text)
 


### PR DESCRIPTION
## Summary
When a Lender marks "Confirm returned", the item immediately returns to their inventory as "available". 

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #533

## Type of Change

- [x] New feature

## Changes Made
<!-- List the key files/components changed and why -->
-
-

## How to Test
1. As Lender, on an item that is being borrowed, choose the option "Confirm returned" - item should return to "available" state immediately. 


## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
Needs a LOT of scrutiny. Claude did this for me. It works in testing, but that doesn't mean it's good to push!