### PR TITLE
Fix stale CSRF token in htmx requests after login rotation

### DIFF
--- a/static/js/htmx-csrf.js
+++ b/static/js/htmx-csrf.js
@@ -1,0 +1,32 @@
+/**
+ * Attaches the CSRF token to every htmx request by reading Django's
+ * `csrftoken` cookie at request time, rather than baking a value rendered
+ * into the page into a static `hx-headers` attribute or a `{% csrf_token %}`
+ * hidden input.
+ *
+ * Either of those goes stale whenever the CSRF cookie rotates after the page
+ * was rendered (e.g. django.contrib.auth.login() rotates it on login),
+ * because a page left open in another tab or restored from bfcache still
+ * carries the pre-rotation token — causing htmx requests from that page to
+ * fail CSRF validation. Reading the cookie live self-heals in those cases.
+ * The `csrfmiddlewaretoken` form field is refreshed too, since Django's
+ * CsrfViewMiddleware prefers a token in the request body over the header
+ * when a form submits both.
+ */
+function getCookie(name) {
+  const match = document.cookie.match(
+    '(?:^|; )' + name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1') + '=([^;]*)',
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+document.body.addEventListener('htmx:configRequest', (event) => {
+  const csrfToken = getCookie('csrftoken');
+  if (!csrfToken) {
+    return;
+  }
+  event.detail.headers['X-CSRFToken'] = csrfToken;
+  if ('csrfmiddlewaretoken' in event.detail.parameters) {
+    event.detail.parameters['csrfmiddlewaretoken'] = csrfToken;
+  }
+});

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,3 +2,4 @@ import "vite/modulepreload-polyfill";
 import "../css/main.css";
 import "./toast.js";
 import "./qrcode-render.js";
+import "./htmx-csrf.js";

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,9 +23,7 @@
             <style id="fouc-guard">body{visibility:hidden}</style><script>document.addEventListener('DOMContentLoaded',function(){var s=document.getElementById('fouc-guard');if(s)s.remove()})</script>
         {% endif %}
     </head>
-    <body x-data
-          class="flex flex-col justify-center min-h-screen bg-base-200"
-          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+    <body x-data class="flex flex-col justify-center min-h-screen bg-base-200">
         {% if borrowd_beta_enabled %}
             {% include "includes/beta.html" %}
 


### PR DESCRIPTION
## Summary
- `templates/base.html` baked the CSRF token into a static `hx-headers` attribute on `<body>` at page-render time. `django.contrib.auth.login()` rotates the CSRF cookie on every login, so a page rendered before that rotation — a second tab, or a page restored from bfcache — kept sending the stale, pre-rotation token on every htmx request, causing a CSRF 403 that only cleared on a manual refresh.
- Replaced the static attribute with an `htmx:configRequest` listener (`static/js/htmx-csrf.js`) that reads the live `csrftoken` cookie at request time and sets both the `X-CSRFToken` header and the `csrfmiddlewaretoken` form field (Django's `CsrfViewMiddleware` prefers a body-submitted token over the header, and the existing htmx-driven forms — notification mark-read/delete, beta signup — already embed `{% csrf_token %}`, so both had to be refreshed).

## Root cause verification
Reproduced the exact failure mode with Playwright against a local dev server: loaded a logged-in page, then rotated the `csrftoken` cookie value in the browser (simulating what `rotate_token()` does on a login elsewhere) without reloading the page, and clicked an htmx "Mark as read" button already present in the DOM.
- **Before this fix:** the stale baked token was sent → **403**.
- **After this fix:** the listener picks up the rotated cookie live → **200**.

## Test plan
- [x] `uv run manage.py test` — all 488 tests pass
- [x] `uvx pre-commit run --all-files` on changed files — clean
- [x] Manual Playwright repro of the stale-cookie/rotation scenario against the running dev server, confirmed 403 → 200 after the fix (see above)

Fixes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)