### PR TITLE
Changes group invitation page to use group banner instead of group logo

### DIFF
--- a/templates/groups/group_join.html
+++ b/templates/groups/group_join.html
@@ -18,8 +18,8 @@
         <div class="card bg-white shadow-sm w-full overflow-hidden">
             <div class="flex gap-3 p-2.5 items-center">
                 <div class="flex-1 min-w-0 overflow-hidden rounded-md">
-                    {% if object.logo %}
-                        <img src="{{ object.logo.url }}"
+                    {% if object.banner %}
+                        <img src="{{ object.banner.url }}"
                              alt="{{ object.name }}"
                              class="w-full h-full object-cover rounded-md" />
                     {% else %}


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. --> Changes group invitation photo from "logo" to "banner" (we only collect banner image in  app now) 

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #532

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->

Updated lines 21/22 in templates/groups/group_join.html

From: 
 {% if object.logo %}                                            
 <img src="{{ object.logo.url }}"                            
 
To: 
{% if object.banner %}                                          
<img src="{{ object.banner.url }}"  


## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Create a new group invitation (make sure group has photo uploaded)
2. Send new user group invitation and see if image shows up. 

## Screenshots (if UI change)
<!-- Before / After if applicable -->
<img width="820" height="777" alt="image" src="https://github.com/user-attachments/assets/68352633-e40e-4a1b-b8b3-f79afa524a42" />
<img width="823" height="778" alt="image" src="https://github.com/user-attachments/assets/b8aa1667-f693-483d-b0d4-f75c01937585" />


## Checklist
- [x] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
