### PR TITLE
Additional fix to address CSRF bug

### DIFF
--- a/borrowd/config/cert/django.py
+++ b/borrowd/config/cert/django.py
@@ -10,6 +10,10 @@ from ..env import env
 
 DEBUG = False
 
+# See borrowd/config/prod/django.py for why this is required behind
+# platform.sh's TLS-terminating router.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 #################################################################################
 # Platform.sh-specific configuration
 

--- a/borrowd/config/prod/django.py
+++ b/borrowd/config/prod/django.py
@@ -10,6 +10,12 @@ from ..env import env
 
 DEBUG = False
 
+# Platform.sh terminates TLS at its router and forwards to gunicorn over
+# plain HTTP, setting X-Forwarded-Proto — without this, request.is_secure()
+# is always False, which makes Django's CSRF Origin check compute
+# "http://..." as the expected origin and reject every real HTTPS POST.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # Beta settings
 BETA_COOKIE_DOMAIN = "app.borrowd.org"
 BETA_SECURE_COOKIE = True


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->
borrowd/config/prod/django.py (and cert/django.py) never set SECURE_PROXY_SSL_HEADER. 
Platform.sh's router terminates TLS and forwards to gunicorn over plain HTTP. Without that setting, Django's request.is_secure() returns False even though the browser is on https://app.borrowd.org.

Fix: add to borrowd/config/prod/django.py (and cert/django.py, since that env sits behind the same platform.sh proxy):
SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https") 
  
That makes is_secure() correctly return True behind the proxy, so good_origin becomes https://app.borrowd.org, matching the browser's Origin header.

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Configuration / infrastructure

## Changes Made
<!-- List the key files/components changed and why -->
-
-

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1.
2.

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [ ] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
