### PR TITLE
Fixes missing secure attribute for cookies 374

### DIFF
--- a/borrowd/config/cert/django.py
+++ b/borrowd/config/cert/django.py
@@ -10,6 +10,12 @@ from ..env import env
 
 DEBUG = False
 
+# See borrowd/config/prod/django.py — same reasoning, cert is also
+# HTTPS-only behind platform.sh's router.
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+BETA_SECURE_COOKIE = True
+
 #################################################################################
 # Platform.sh-specific configuration
 

--- a/borrowd/config/prod/django.py
+++ b/borrowd/config/prod/django.py
@@ -10,6 +10,11 @@ from ..env import env
 
 DEBUG = False
 
+# HTTPS is the only way in (platform.sh's router), so it's safe to mark
+# every cookie Secure-only — see https://github.com/borrowd/borrowd/issues/374
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
 # Beta settings
 BETA_COOKIE_DOMAIN = "app.borrowd.org"
 BETA_SECURE_COOKIE = True


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->Marks sessionid, csrftoken, and beta_key cookies Secure 

## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #374 

## Type of Change
- [x] Bug fix

## Changes Made
<!-- List the key files/components changed and why -->
  - borrowd/config/prod/django.py: added SESSION_COOKIE_SECURE = True, CSRF_COOKIE_SECURE = True
  - borrowd/config/cert/django.py: added SESSION_COOKIE_SECURE = True, CSRF_COOKIE_SECURE = True, and
  BETA_SECURE_COOKIE = True 

Excluded: dev/base config — local dev serves over plain HTTP, so forcing Secure there would break login/CSRF on localhost.

Note: Independent of the open CSRF fix in #557 (csrf-fix2) — no file overlap, this only touches the Secure cookie flags, not the Origin/proxy header handling.

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1.
2.

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [ ] I have tested this locally
- [ ] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
