### PR TITLE
Autosaves picture when a user uploads a profile photo

### DIFF
--- a/borrowd_users/forms.py
+++ b/borrowd_users/forms.py
@@ -6,6 +6,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import UploadedFile
+from django.core.validators import FileExtensionValidator
+from django.template.defaultfilters import filesizeformat
 
 from .models import BorrowdUser, Profile
 
@@ -13,6 +16,21 @@ User = get_user_model()
 
 # Common field styles
 INPUT_CLASSES = "input w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-borrowd-indigo-500 focus:border-borrowd-indigo-500"
+
+MAX_PROFILE_PHOTO_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+ALLOWED_PROFILE_IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp"]
+ALLOWED_PROFILE_IMAGE_ACCEPT = ",".join(
+    f".{ext}" for ext in ALLOWED_PROFILE_IMAGE_EXTENSIONS
+)
+
+
+def validate_profile_photo_size(image: UploadedFile) -> None:
+    """Validate that an uploaded profile photo doesn't exceed the maximum file size."""
+    if image.size and image.size > MAX_PROFILE_PHOTO_SIZE_BYTES:
+        raise forms.ValidationError(
+            f"File size must be under {filesizeformat(MAX_PROFILE_PHOTO_SIZE_BYTES)}. "
+            f"Your file is {filesizeformat(image.size)}."
+        )
 
 
 # Factory functions for creating form fields with consistent styling
@@ -169,21 +187,32 @@ class ProfileUpdateForm(forms.ModelForm[Profile]):
     first_name = create_first_name_field()
     last_name = create_last_name_field()
 
+    image = forms.ImageField(
+        required=False,
+        validators=[
+            FileExtensionValidator(allowed_extensions=ALLOWED_PROFILE_IMAGE_EXTENSIONS)
+        ],
+        widget=forms.FileInput(
+            attrs={
+                "class": "file-input file-input-bordered w-full sr-only",
+                "id": "id_image",
+                "accept": ALLOWED_PROFILE_IMAGE_ACCEPT,
+            }
+        ),
+    )
+
     class Meta:
         model = Profile
         fields = ["image", "bio"]
-        widgets = {
-            "image": forms.FileInput(
-                attrs={
-                    "class": "file-input file-input-bordered w-full sr-only",
-                    "id": "id_image",
-                    "accept": "image/*",
-                }
-            ),
-        }
 
     email = create_email_field()
     bio = create_bio_field()
+
+    def clean_image(self) -> UploadedFile | None:
+        image: UploadedFile | None = self.cleaned_data.get("image")
+        if image:
+            validate_profile_photo_size(image)
+        return image
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -232,6 +261,23 @@ class ProfileUpdateForm(forms.ModelForm[Profile]):
             profile.save()
 
         return profile
+
+
+class ProfilePhotoUploadForm(forms.Form):
+    """Validates a single profile photo upload, independent of the rest of
+    ProfileUpdateForm's fields, for the auto-save-on-select upload endpoint."""
+
+    image = forms.ImageField(
+        required=True,
+        validators=[
+            FileExtensionValidator(allowed_extensions=ALLOWED_PROFILE_IMAGE_EXTENSIONS)
+        ],
+    )
+
+    def clean_image(self) -> UploadedFile:
+        image: UploadedFile = self.cleaned_data["image"]
+        validate_profile_photo_size(image)
+        return image
 
 
 class ChangePasswordForm(SetPasswordForm):

--- a/borrowd_users/tests/test_profile_photo_upload.py
+++ b/borrowd_users/tests/test_profile_photo_upload.py
@@ -1,0 +1,107 @@
+"""
+Tests for the auto-save-on-select profile photo upload endpoint.
+
+Covers:
+- upload_profile_photo_view saving a new/replacement profile photo
+- ProfilePhotoUploadForm extension/size validation
+- auth/method guards on the endpoint
+"""
+
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from PIL import Image
+
+from borrowd_users.forms import MAX_PROFILE_PHOTO_SIZE_BYTES
+from borrowd_users.models import BorrowdUser
+
+
+def create_test_image(
+    size_bytes: int | None = None,
+    format: str = "JPEG",
+    filename: str = "photo.jpg",
+    content_type: str = "image/jpeg",
+) -> SimpleUploadedFile:
+    image = Image.new("RGB", (100, 100), color="blue")
+    buffer = BytesIO()
+    image.save(buffer, format=format)
+
+    if size_bytes is not None and size_bytes > buffer.tell():
+        buffer.write(b"\x00" * (size_bytes - buffer.tell()))
+
+    buffer.seek(0)
+    return SimpleUploadedFile(filename, buffer.read(), content_type=content_type)
+
+
+class UploadProfilePhotoViewTests(TestCase):
+    def setUp(self) -> None:
+        self.user = BorrowdUser.objects.create_user(
+            username="photo_uploader",
+            email="photo_uploader@example.com",
+            password="password",
+        )
+        self.url = reverse("profile-upload-photo")
+
+    def test_upload_saves_image_and_returns_url(self) -> None:
+        self.client.force_login(self.user)
+
+        response = self.client.post(self.url, {"image": create_test_image()})
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["success"])
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.image)
+        self.assertEqual(data["image_url"], self.user.profile.image.url)
+
+    def test_upload_replaces_existing_image(self) -> None:
+        self.client.force_login(self.user)
+        self.client.post(self.url, {"image": create_test_image(filename="first.jpg")})
+        self.user.profile.refresh_from_db()
+        first_image_name = self.user.profile.image.name
+
+        response = self.client.post(
+            self.url, {"image": create_test_image(filename="second.jpg")}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.profile.refresh_from_db()
+        self.assertNotEqual(self.user.profile.image.name, first_image_name)
+
+    def test_upload_rejects_disallowed_extension(self) -> None:
+        self.client.force_login(self.user)
+        bad_file = SimpleUploadedFile(
+            "notes.txt", b"not an image", content_type="text/plain"
+        )
+
+        response = self.client.post(self.url, {"image": bad_file})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json()["success"])
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.image)
+
+    def test_upload_rejects_oversized_file(self) -> None:
+        self.client.force_login(self.user)
+        oversized = create_test_image(size_bytes=MAX_PROFILE_PHOTO_SIZE_BYTES + 1)
+
+        response = self.client.post(self.url, {"image": oversized})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json()["success"])
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.image)
+
+    def test_upload_requires_login(self) -> None:
+        response = self.client.post(self.url, {"image": create_test_image()})
+
+        self.assertEqual(response.status_code, 302)
+
+    def test_upload_requires_post(self) -> None:
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 405)

--- a/borrowd_users/urls.py
+++ b/borrowd_users/urls.py
@@ -9,11 +9,13 @@ from .views import (
     profile_view,
     public_profile_view,
     search_terms_export_view,
+    upload_profile_photo_view,
 )
 
 urlpatterns = [
     path("", profile_view, name="profile"),
     path("delete-photo/", delete_profile_photo_view, name="profile-delete-photo"),
+    path("upload-photo/", upload_profile_photo_view, name="profile-upload-photo"),
     path("profile-deleted/", profile_deleted_view, name="profile-deleted"),
     path("search-terms/export/", search_terms_export_view, name="search-terms-export"),
     path("signup/", CustomSignupView.as_view(), name="custom_signup"),

--- a/borrowd_users/views.py
+++ b/borrowd_users/views.py
@@ -31,7 +31,12 @@ from borrowd_items.models import Item, ItemStatus, Transaction
 from borrowd_notifications.models import NotificationPreference
 
 from .exceptions import AccountDeletionBlocked
-from .forms import ChangePasswordForm, CustomSignupForm, ProfileUpdateForm
+from .forms import (
+    ChangePasswordForm,
+    CustomSignupForm,
+    ProfilePhotoUploadForm,
+    ProfileUpdateForm,
+)
 from .models import BorrowdUser, SearchTarget, SearchTerm
 from .request import get_authenticated_user
 from .services import soft_delete_account
@@ -237,6 +242,38 @@ def delete_profile_photo_view(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
         {"success": False, "message": "No profile picture to delete."},
         status=400,
+    )
+
+
+@login_required
+@require_POST
+def upload_profile_photo_view(request: HttpRequest) -> JsonResponse:
+    """
+    Save the user's profile photo via AJAX as soon as one is selected,
+    without affecting other form fields -- see delete_profile_photo_view
+    above for why this needs to be its own endpoint rather than part of
+    ProfileUpdateForm's regular submit.
+    """
+    user = get_authenticated_user(request)
+    profile = user.profile
+
+    form = ProfilePhotoUploadForm(request.POST, request.FILES)
+    if not form.is_valid():
+        message = next(iter(form.errors.get("image", [])), "Invalid image.")
+        return JsonResponse({"success": False, "message": message}, status=400)
+
+    if profile.image:
+        profile.image.delete(save=False)
+    profile.image = form.cleaned_data["image"]
+    profile.updated_by = user
+    profile.save()
+
+    return JsonResponse(
+        {
+            "success": True,
+            "message": "Profile photo updated.",
+            "image_url": profile.image.url,
+        }
     )
 
 

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -101,7 +101,7 @@
                 {# Personal fields #}
                 <details class="card bg-primary-content transition-colors"
                          :class="openDrawer === 'info' ? 'rounded-md border border-gray-200 shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] p-4 flex flex-col gap-2 ' : 'border border-gray-200 shadow-sm rounded-md flex flex-row items-center justify-between px-4 py-3 hover:bg-base-200'">
-                    <summary class="w-full flex flex-row items-center justify-between cursor-pointer "
+                    <summary class="w-full flex flex-row items-center justify-between cursor-pointer"
                              @click="openDrawer = openDrawer === 'info' ? null : 'info'">
                         <span class="text-base-content px-1"
                               :class="openDrawer === 'info' ? 'text-xs font-semibold' : 'text-sm '">
@@ -164,11 +164,11 @@
                 {% trans "Stats" %}
             </p>
 
-            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 ">
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {% for stat in profile_stats %}
                     <div class="flex items-center justify-between gap-3 border border-gray-200 bg-base-200 rounded-xl p-2">
                         <div class="flex flex-row gap-2 items-center">
-                            <div class="w-7 h-7 flex  items-center justify-center flex-shrink-0">
+                            <div class="w-7 h-7 flex items-center justify-center flex-shrink-0">
                                 {% heroicon_micro stat.icon class=stat.icon_class %}
                             </div>
                             <p class="text-xs text-base-content">
@@ -183,7 +183,7 @@
             </section>
 
             {# ── Security ──────────────────────────────────────────────────── #}
-            <section class="flex flex-col gap-2 ">
+            <section class="flex flex-col gap-2">
                 <p class="text-xs font-semibold text-base-content px-1">
                     {% trans "Security" %}
                 </p>
@@ -424,15 +424,49 @@
   const avatarPreview = document.getElementById('avatar-preview');
   const deleteBtn = document.getElementById('delete-avatar-btn');
 
-  // Live preview on new file select
+  // Live preview + auto-save on new file select
   if (imageInput) {
     imageInput.addEventListener('change', function (e) {
       const file = e.target.files[0];
-      if (file) {
+      if (!file) return;
+
+      const previousSrc = avatarPreview.src;
+      // Only preview files that look like images -- accept="image/*" is a
+      // picker hint the user can bypass, and feeding a non-image data URL
+      // into the <img> would trip its one-shot onerror fallback (which
+      // permanently swaps in the placeholder icon with no way back short
+      // of a reload). The upload's own error toast covers rejected files.
+      if (file.type.startsWith('image/')) {
         const reader = new FileReader();
         reader.onload = function (e) { avatarPreview.src = e.target.result; };
         reader.readAsDataURL(file);
       }
+
+      const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+      const formData = new FormData();
+      formData.append('image', file);
+
+      fetch('{% url "profile-upload-photo" %}', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': csrfToken },
+        body: formData,
+      })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (data.success) {
+          avatarPreview.src = data.image_url;
+          if (deleteBtn) deleteBtn.disabled = false;
+          showToast(data.message);
+        } else {
+          avatarPreview.src = previousSrc;
+          showToast(data.message || 'An error occurred.', 'error');
+        }
+      })
+      .catch(function () {
+        avatarPreview.src = previousSrc;
+        showToast('An error occurred while uploading your profile picture.', 'error');
+      })
+      .finally(function () { imageInput.value = ''; });
     });
   }
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->Profile photos now save automatically when selected, instead of requiring a manual  "Save" click (previously the picture was silently lost if the user navigated away before clicking save).


## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #545 

## Type of Change
- [x] Bug fix

## Changes Made
<!-- List the key files/components changed and why -->
- borrowd_users/forms.py: added ProfilePhotoUploadForm (extension allowlist: jpg/jpeg/png/webp, 5MB size cap) for the new upload endpoint; hardened ProfileUpdateForm.image with the same validators as a no-JS fallback.
- borrowd_users/views.py: added upload_profile_photo_view — POST-only, saves the photo immediately and deletes any prior one, returns JSON. Mirrors the existing delete_profile_photo_view pattern (kept separate from the main profile form so other in-progress fields like bio/email aren't submitted along with it).
- borrowd_users/urls.py: new profile-upload-photo route.
- templates/users/profile.html: the avatar file input now POSTs the selected file via fetch/FormData on change, shows a toast, updates the preview, and enables the Delete button - no page reload or form submit needed.

Bug found and fixed along the way (surfaced by browser-testing the change): the existing local preview used FileReader to render any selected file into the avatar <img>, since accept="image/*" is only a picker hint a user can bypass. A non-image file tripped the <img>'s one-shot onerror handler, permanently swapping in the placeholder icon with no way back short of a reload, even though the server correctly rejected the file. Fixed by gating the local preview on file.type.startsWith('image/'). Also fixed the new error toasts, which were rendering green (alert-success) instead of red (alert-error).

Also fixed: borrowd_users/tests/ was missing __init__.py, silently excluding its 4 test files (39 tests) from the full manage.py test run — added it, surfacing 3 pre-existing test files that were never actually running in CI.


## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Go to profile page. Delete photo or upload a new photo. 
2. Choose new photo for profile. 
3. Navigate to new part of website 
4. Go back to profile to verify photo was saved

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
