### PR TITLE
Adds ability for pending group member to cancel their request

### DIFF
--- a/borrowd_groups/tests/test_membership_approval_flow.py
+++ b/borrowd_groups/tests/test_membership_approval_flow.py
@@ -210,3 +210,97 @@ class MembershipApprovalFlowTests(TestCase):
 
         self.assertEqual(member_response.status_code, 200)
         self.assertNotIn("pending_members", member_response.context)
+
+
+class CancelMembershipRequestTests(TestCase):
+    def setUp(self) -> None:
+        self.moderator = BorrowdUser.objects.create_user(
+            username="cancel_moderator", password="password"
+        )
+        self.requester = BorrowdUser.objects.create_user(
+            username="cancel_requester", password="password"
+        )
+        self.group = BorrowdGroup.objects.create(
+            name="Cancel Group",
+            created_by=self.moderator,
+            updated_by=self.moderator,
+            membership_requires_approval=True,
+        )
+
+    def _cancel_url(self) -> str:
+        return reverse("borrowd_groups:cancel-membership-request", args=[self.group.pk])
+
+    def test_requester_can_cancel_their_own_pending_request(self) -> None:
+        membership = self.group.add_user(self.requester)
+        self.assertEqual(membership.status, MembershipStatus.PENDING)
+
+        self.client.force_login(self.requester)
+        response = self.client.post(self._cancel_url(), follow=True)
+
+        self.assertRedirects(response, reverse("borrowd_groups:group-list"))
+        self.assertFalse(Membership.objects.filter(pk=membership.pk).exists())
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertIn("Your request has been cancelled.", messages_list)
+
+    def test_cancelling_does_not_affect_other_pending_requesters(self) -> None:
+        other_requester = BorrowdUser.objects.create_user(
+            username="cancel_other_requester", password="password"
+        )
+        membership = self.group.add_user(self.requester)
+        other_membership = self.group.add_user(other_requester)
+
+        self.client.force_login(self.requester)
+        self.client.post(self._cancel_url())
+
+        self.assertFalse(Membership.objects.filter(pk=membership.pk).exists())
+        other_membership.refresh_from_db()
+        self.assertEqual(other_membership.status, MembershipStatus.PENDING)
+
+    def test_cancel_requires_login(self) -> None:
+        self.group.add_user(self.requester)
+
+        response = self.client.post(self._cancel_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("account_login"), response["Location"])
+
+    def test_cancel_404s_for_a_nonexistent_group(self) -> None:
+        self.client.force_login(self.requester)
+
+        response = self.client.post(
+            reverse("borrowd_groups:cancel-membership-request", args=[999999])
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_user_without_a_pending_request_gets_an_error_message(self) -> None:
+        self.client.force_login(self.requester)
+
+        response = self.client.post(self._cancel_url(), follow=True)
+
+        self.assertRedirects(response, reverse("borrowd_groups:group-list"))
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertIn("You don't have a pending request for this group.", messages_list)
+
+    def test_active_member_cannot_cancel_their_active_membership_via_this_view(
+        self,
+    ) -> None:
+        active_member = BorrowdUser.objects.create_user(
+            username="cancel_active_member", password="password"
+        )
+        BorrowdGroup.objects.filter(pk=self.group.pk).update(
+            membership_requires_approval=False
+        )
+        self.group.refresh_from_db()
+        membership = self.group.add_user(active_member)
+        self.assertEqual(membership.status, MembershipStatus.ACTIVE)
+
+        self.client.force_login(active_member)
+        response = self.client.post(
+            reverse("borrowd_groups:cancel-membership-request", args=[self.group.pk]),
+            follow=True,
+        )
+
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertIn("You don't have a pending request for this group.", messages_list)
+        self.assertTrue(Membership.objects.filter(pk=membership.pk).exists())

--- a/borrowd_groups/urls.py
+++ b/borrowd_groups/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     ApproveMemberView,
     BecomeModeratorView,
+    CancelMembershipRequestView,
     DenyMemberView,
     GroupCreateView,
     GroupDetailView,
@@ -41,6 +42,11 @@ urlpatterns = [
         "<int:pk>/leave/",
         LeaveGroupView.as_view(),
         name="leave-group",
+    ),
+    path(
+        "<int:pk>/cancel-request/",
+        CancelMembershipRequestView.as_view(),
+        name="cancel-membership-request",
     ),
     path(
         "<int:pk>/become-moderator/",

--- a/borrowd_groups/views.py
+++ b/borrowd_groups/views.py
@@ -629,6 +629,35 @@ class DenyMemberView(LoginRequiredMixin, View):
         return redirect("borrowd_groups:group-detail", pk=membership.group.pk)
 
 
+class CancelMembershipRequestView(LoginRequiredMixin, View):
+    """
+    Allows a user to cancel their own PENDING request to join a group.
+
+    A PENDING membership grants no group permissions (see
+    refresh_permissions_on_membership_update), so the requester can't reach
+    GroupDetailView / LeaveGroupView to back out -- this is their only way
+    to withdraw a request awaiting moderator approval.
+    """
+
+    def post(
+        self, request: HttpRequest, pk: int
+    ) -> HttpResponsePermanentRedirect | HttpResponseRedirect:
+        group = get_object_or_404(BorrowdGroup, pk=pk)
+        user = get_authenticated_user(request)
+
+        membership = Membership.objects.filter(
+            user=user, group=group, status=MembershipStatus.PENDING
+        ).first()
+
+        if membership is None:
+            messages.error(request, "You don't have a pending request for this group.")
+            return redirect("borrowd_groups:group-list")
+
+        membership.delete()
+        messages.success(request, "Your request has been cancelled.")
+        return redirect("borrowd_groups:group-list")
+
+
 class LeaveGroupView(LoginRequiredMixin, View):
     """
     Allow a group member to leave a group.

--- a/templates/groups/group_list_card.html
+++ b/templates/groups/group_list_card.html
@@ -5,14 +5,10 @@
     <!-- Header -->
     <div class="flex items-center gap-3 px-2.5 py-2.5 bg-white border-b border-gray-200">
         <div class="label flex-1">
-            <span class="text-xs font-semibold text-base-content-scale-70">
-                Group
-            </span>
+            <span class="text-xs font-semibold text-base-content-scale-70">Group</span>
         </div>
         <div class="label">
-            <span class="text-xs font-semibold text-base-content-scale-70">
-                Members
-            </span>
+            <span class="text-xs font-semibold text-base-content-scale-70">Members</span>
         </div>
     </div>
 
@@ -49,9 +45,15 @@
                         {% endif %}
 
                         {% if membership.status == "PENDING" %}
-                            <span class="inline-block badge badge-warning badge-soft text-xs px-2 py-1 rounded font-semibold">
-                                Pending
-                            </span>
+                            <span class="inline-block badge badge-warning badge-soft text-xs px-2 py-1 rounded font-semibold">Pending</span>
+                            <form method="post"
+                                  action="{% url 'borrowd_groups:cancel-membership-request' membership.group.pk %}"
+                                  onsubmit="return confirm('Cancel your request to join {{ membership.group.name|escapejs }}?');">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-ghost btn-xs text-yellow-700">
+                                    Cancel
+                                </button>
+                            </form>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph max. -->A a user with a PENDING group membership (awaiting moderator approval) had no way to cancel their own request. LeaveGroupView explicitly requires ACTIVE status, and a PENDING membership grants zero group permissions (see refresh_permissions_on_membership_update), so the group detail page (where "Leave group" lives) isn't even reachable for a pending requester. Their only prior option was to wait indefinitely.


## Linked Issue(s)
<!-- Closes #[issue number] -->
Closes #498 

## Type of Change
- [x] Bug fix

## Changes Made
<!-- List the key files/components changed and why -->
- borrowd_groups/views.py: added CancelMembershipRequestView, a self-service mirror of the existing moderator-only DenyMemberView, scoped to the requester's own PENDING membership.
- borrowd_groups/urls.py: new <int:pk>/cancel-request/ route, cancel-membership-request.
- templates/groups/group_list_card.html: added a "Cancel" button next to the "Pending" badge

## How to Test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Create a group requiring moderator approval
2. Send invitation to new user; join group
3. While group status is "pending" see/test cancel

## Screenshots (if UI change)
<!-- Before / After if applicable -->

## Checklist
- [x] I have tested this locally
- [x] I have added/updated relevant tests
- [ ] I have checked this works for both moderators and regular members (if relevant)
- [ ] No debug logs, or unrelated changes included
- [ ] Migrations are included (if model changes were made)

## Risk / Notes for Reviewer
<!-- Any edge cases, potential regressions, or areas that need extra scrutiny -->
